### PR TITLE
#22 feature: 인증 API 연동 및 로그인/회원가입 흐름 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+.env
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,0 +1,57 @@
+import { apiFetch } from './client';
+import type {
+  LoginRequest,
+  LoginResponse,
+  LogoutRequest,
+  LogoutResponse,
+  RefreshRequest,
+  RefreshResponse,
+  SendEmailCodeRequest,
+  SendEmailCodeResponse,
+  SignupRequest,
+  SignupResponse,
+  VerifyEmailCodeRequest,
+  VerifyEmailCodeResponse,
+} from './types';
+
+export function loginApi(body: LoginRequest) {
+  return apiFetch<LoginResponse>('/api/auth/login', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function signupApi(body: SignupRequest) {
+  return apiFetch<SignupResponse>('/api/auth/signup', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function sendEmailCodeApi(body: SendEmailCodeRequest) {
+  return apiFetch<SendEmailCodeResponse>('/api/auth/email/send', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function verifyEmailCodeApi(body: VerifyEmailCodeRequest) {
+  return apiFetch<VerifyEmailCodeResponse>('/api/auth/email/verify', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function refreshApi(body: RefreshRequest) {
+  return apiFetch<RefreshResponse>('/api/auth/refresh', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export function logoutApi(body: LogoutRequest) {
+  return apiFetch<LogoutResponse>('/api/auth/logout', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}

--- a/api/client.ts
+++ b/api/client.ts
@@ -1,0 +1,39 @@
+// Expo public env는 번들 시점에 주입되므로 앱 재시작이 필요합니다.
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.trim() ?? '';
+
+type ApiFetchOptions = RequestInit & {
+  accessToken?: string | null;
+};
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  if (!BASE_URL) {
+    throw new Error('EXPO_PUBLIC_API_BASE_URL이 없습니다. Metro 서버를 재시작해 주세요.');
+  }
+
+  const headers = new Headers(options.headers);
+  // 중복 슬래시로 잘못된 URL이 만들어지지 않도록 정규화합니다.
+  const normalizedBaseUrl = BASE_URL.replace(/\/+$/, '');
+
+  headers.set('Content-Type', 'application/json');
+  headers.set('Accept', 'application/json');
+
+  if (options.accessToken) {
+    headers.set('Authorization', `Bearer ${options.accessToken}`);
+  }
+
+  const response = await fetch(`${normalizedBaseUrl}${path}`, {
+    ...options,
+    headers,
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+  const data = isJson ? await response.json() : null;
+
+  if (!response.ok) {
+    const message = data?.message ?? `요청에 실패했습니다. status=${response.status}`;
+    throw new Error(message);
+  }
+
+  return data as T;
+}

--- a/api/client.ts
+++ b/api/client.ts
@@ -1,3 +1,7 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
 // Expo public env는 번들 시점에 주입되므로 앱 재시작이 필요합니다.
 const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.trim() ?? '';
 

--- a/api/types.ts
+++ b/api/types.ts
@@ -1,0 +1,55 @@
+export type ApiResponse<T> = {
+  data: T;
+  message: string;
+};
+
+export type LoginRequest = {
+  email: string;
+  password: string;
+};
+
+export type SignupRequest = {
+  email: string;
+  password: string;
+  name: string;
+  address: string;
+};
+
+export type SendEmailCodeRequest = {
+  email: string;
+};
+
+export type VerifyEmailCodeRequest = {
+  email: string;
+  code: string;
+};
+
+export type RefreshRequest = {
+  refreshToken: string;
+};
+
+export type LogoutRequest = {
+  refreshToken: string;
+};
+
+export type AuthTokenPayload = {
+  userId: number;
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type LoginResponse = ApiResponse<AuthTokenPayload>;
+export type SignupResponse = ApiResponse<AuthTokenPayload>;
+
+export type RefreshResponse = ApiResponse<{
+  accessToken: string;
+  refreshToken: string;
+}>;
+
+export type SendEmailCodeResponse = ApiResponse<string>;
+
+export type VerifyEmailCodeResponse = ApiResponse<{
+  email: string;
+}>;
+
+export type LogoutResponse = ApiResponse<string>;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,9 @@
 import { Stack, useRouter, useSegments, useRootNavigationState } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useEffect } from 'react';
-import { useIsLoggedIn } from '../store/useAuthStore';
+import { ActivityIndicator, View } from 'react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAuthActions, useIsInitialized, useIsLoggedIn } from '../store/useAuthStore';
 
 // ──────────────────────────────────────────────────────────────────
 // 라우트 가드 컴포넌트
@@ -12,19 +14,29 @@ import { useIsLoggedIn } from '../store/useAuthStore';
 
 // 인증 없이 접근 가능한 퍼블릭 라우트 목록
 const PUBLIC_ROUTES = ['login', 'register'];
+// 앱 전역에서 같은 QueryClient를 재사용합니다.
+const queryClient = new QueryClient();
 
 function RouteGuard() {
   const router = useRouter();
   const segments = useSegments();
   const isLoggedIn = useIsLoggedIn();
+  const isInitialized = useIsInitialized();
+  const { initializeAuth } = useAuthActions();
 
   // 네비게이터 마운트 완료 여부 확인
   // key가 undefined이면 아직 Stack이 준비되지 않은 상태
   const navigationState = useRootNavigationState();
 
   useEffect(() => {
-    // 네비게이터가 준비되지 않으면 리다이렉트를 실행하지 않음
+    // 앱 시작 시 저장된 RT로 로그인 상태를 먼저 복구합니다.
+    void initializeAuth();
+  }, [initializeAuth]);
+
+  useEffect(() => {
+    // 네비게이터 준비 전이나 세션 복원 전에는 리다이렉트를 막습니다.
     if (!navigationState?.key) return;
+    if (!isInitialized) return;
 
     const currentSegment = segments[0] as string | undefined;
     const isPublicRoute = PUBLIC_ROUTES.includes(currentSegment ?? '');
@@ -37,17 +49,28 @@ function RouteGuard() {
       // 로그인 상태에서 /login 또는 /register 접근 → 홈으로 리다이렉트
       router.replace('/');
     }
-  }, [isLoggedIn, segments, navigationState?.key]);
+  }, [isInitialized, isLoggedIn, router, segments, navigationState?.key]);
+
+  if (!isInitialized) {
+    return (
+      // 세션 복원 중에는 잠깐 로딩만 보여줍니다.
+      <View className="absolute inset-0 items-center justify-center bg-white">
+        <ActivityIndicator size="large" color="#4B8B3B" />
+      </View>
+    );
+  }
 
   return null;
 }
 
 export default function RootLayout() {
   return (
-    <SafeAreaProvider>
-      {/* Stack을 먼저 렌더링하여 네비게이터를 마운트한 뒤 RouteGuard 실행 */}
-      <Stack screenOptions={{ headerShown: false }} />
-      <RouteGuard />
-    </SafeAreaProvider>
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaProvider>
+        {/* Stack을 먼저 렌더링하여 네비게이터를 마운트한 뒤 RouteGuard 실행 */}
+        <Stack screenOptions={{ headerShown: false }} />
+        <RouteGuard />
+      </SafeAreaProvider>
+    </QueryClientProvider>
   );
 }

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -81,7 +81,7 @@ export default function LoginPage() {
               <View className="flex-row items-center border-b border-gray-300">
                 <TextInput
                   className="flex-1 py-2 text-base text-gray-900"
-                  placeholder=""
+                  placeholder="비밀번호를 입력해주세요"
                   placeholderTextColor="#9CA3AF"
                   value={password}
                   onChangeText={setPassword}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -11,21 +11,25 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { useAuthActions } from '../store/useAuthStore';
 import { COLORS } from '../constants/theme';
+import { useLoginMutation } from '../hooks/auth/useLoginMutation';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login } = useAuthActions();
+  const loginMutation = useLoginMutation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-  // 로그인 버튼 클릭 시 isLoggedIn = true 설정
-  // RouteGuard가 상태 변경을 감지하여 자동으로 / 으로 리다이렉트합니다.
-  // [TODO] 실제 API 호출 후 성공 시 login() 호출하도록 수정 필요
   const handleLogin = () => {
-    login();
+    if (!email.trim() || !password.trim()) {
+      return;
+    }
+
+    loginMutation.mutate({
+      email: email.trim(),
+      password,
+    });
   };
 
   // 회원가입 버튼 클릭 시 회원가입 페이지로 이동
@@ -93,12 +97,23 @@ export default function LoginPage() {
               </View>
             </View>
 
+            {loginMutation.isError && (
+              <Text className="mb-4 text-sm text-red-500">
+                {loginMutation.error instanceof Error
+                  ? loginMutation.error.message
+                  : '로그인에 실패했습니다.'}
+              </Text>
+            )}
+
             {/* 로그인 버튼 */}
             <TouchableOpacity
               onPress={handleLogin}
+              disabled={loginMutation.isPending}
               className="mb-6 items-center rounded-full py-4"
-              style={{ backgroundColor: COLORS.primary }}>
-              <Text className="text-base font-semibold text-white">로그인</Text>
+              style={{ backgroundColor: loginMutation.isPending ? '#A3A3A3' : COLORS.primary }}>
+              <Text className="text-base font-semibold text-white">
+                {loginMutation.isPending ? '로그인 중...' : '로그인'}
+              </Text>
             </TouchableOpacity>
 
             {/* 회원가입 링크 */}

--- a/app/mypage.tsx
+++ b/app/mypage.tsx
@@ -1,6 +1,5 @@
 import { View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import TabBar from '../components/layout/TabBar';
 import { COLORS } from '../constants/theme';
@@ -8,7 +7,6 @@ import { MOCK_MILESTONES, MOCK_REWARDS, MOCK_FERTILITY } from '../mocks/mypage';
 import { useAuthActions } from '../store/useAuthStore';
 
 export default function MyPage() {
-  const router = useRouter();
   const { logout } = useAuthActions();
   const fertilityProgress = MOCK_FERTILITY.progress;
 

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   View,
   Text,
@@ -11,45 +10,129 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
 import { COLORS } from '../constants/theme';
-import { useAuthActions } from '../store/useAuthStore';
 import EmailVerifyModal from '../components/modals/EmailVerifyModal';
+import { useSendEmailCodeMutation } from '../hooks/auth/useSendEmailCodeMutation';
+import { useSignupMutation } from '../hooks/auth/useSignupMutation';
+import { useVerifyEmailCodeMutation } from '../hooks/auth/useVerifyEmailCodeMutation';
+
+const EMAIL_VERIFY_EXPIRE_SECONDS = 10 * 60;
 
 export default function RegisterPage() {
   const router = useRouter();
-  const { login } = useAuthActions();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [name, setName] = useState('');
   const [address, setAddress] = useState('');
-
-  // 이메일 인증 모달 상태
   const [isVerifyModalVisible, setIsVerifyModalVisible] = useState(false);
+  const [isEmailVerified, setIsEmailVerified] = useState(false);
+  const [verifiedEmail, setVerifiedEmail] = useState('');
+  const [expireAt, setExpireAt] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+
+  const sendEmailCodeMutation = useSendEmailCodeMutation();
+  const verifyEmailCodeMutation = useVerifyEmailCodeMutation();
+  const signupMutation = useSignupMutation();
+
+  // 남은 인증 시간을 초 단위로 계산합니다.
+  const remainingSeconds = useMemo(() => {
+    if (!expireAt) {
+      return 0;
+    }
+
+    const seconds = Math.ceil((expireAt - now) / 1000);
+    return seconds > 0 ? seconds : 0;
+  }, [expireAt, now]);
+
+  useEffect(() => {
+    if (!expireAt || remainingSeconds === 0) {
+      return;
+    }
+
+    // 모달 타이머 표기를 1초마다 갱신합니다.
+    const timer = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [expireAt, remainingSeconds]);
 
   // 뒤로가기 → 로그인 페이지
   const handleBack = () => {
     router.back();
   };
 
-  // 이메일 인증하기 버튼
   const handleOpenVerifyModal = () => {
-    setIsVerifyModalVisible(true);
-    // [TODO] 이메일 인증 코드 발송 API 호출
+    const normalizedEmail = email.trim();
+
+    if (!normalizedEmail) {
+      return;
+    }
+
+    sendEmailCodeMutation.mutate(
+      { email: normalizedEmail },
+      {
+        onSuccess: () => {
+          // 재전송 시에는 이전 인증 결과와 만료 시간을 모두 초기화합니다.
+          setIsEmailVerified(false);
+          setVerifiedEmail('');
+          setExpireAt(Date.now() + EMAIL_VERIFY_EXPIRE_SECONDS * 1000);
+          setNow(Date.now());
+          setIsVerifyModalVisible(true);
+        },
+      }
+    );
   };
 
-  // 인증 완료 → login() 호출, RouteGuard가 / 로 리다이렉트
-  // [TODO] 인증 코드 검증 API 성공 후 호출하도록 수정
-  const handleVerifyComplete = () => {
-    setIsVerifyModalVisible(false);
-    login();
+  const handleVerifyComplete = (code: string) => {
+    const normalizedEmail = email.trim();
+
+    verifyEmailCodeMutation.mutate(
+      { email: normalizedEmail, code },
+      {
+        onSuccess: () => {
+          // 현재 입력한 이메일만 인증 완료 상태로 인정합니다.
+          setIsEmailVerified(true);
+          setVerifiedEmail(normalizedEmail);
+          setIsVerifyModalVisible(false);
+        },
+      }
+    );
   };
 
-  // 회원가입 버튼 클릭 (추후 API 연동)
   const handleRegister = () => {
-    // [TODO] 회원가입 API 호출 후 성공 시 handleVerifyComplete 호출
-    console.log('회원가입 버튼 클릭', { email, password, name, address });
+    const normalizedEmail = email.trim();
+
+    if (!isEmailVerified || verifiedEmail !== normalizedEmail) {
+      return;
+    }
+
+    signupMutation.mutate(
+      {
+        email: normalizedEmail,
+        password,
+        name: name.trim(),
+        address: address.trim(),
+      },
+      {
+        onSuccess: () => {
+          // 이번 정책에서는 가입 직후 로그인하지 않고 로그인 화면으로 이동합니다.
+          router.replace('/login');
+        },
+      }
+    );
   };
+
+  const isRegisterDisabled =
+    !email.trim() ||
+    !password.trim() ||
+    !name.trim() ||
+    !address.trim() ||
+    !isEmailVerified ||
+    verifiedEmail !== email.trim() ||
+    signupMutation.isPending;
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={['top', 'bottom']}>
@@ -104,7 +187,13 @@ export default function RegisterPage() {
                   placeholder="예) 12345678@hanbat.edu.kr"
                   placeholderTextColor="#9CA3AF"
                   value={email}
-                  onChangeText={setEmail}
+                  onChangeText={(value) => {
+                    // 이메일이 바뀌면 이전 인증 결과는 더 이상 유효하지 않습니다.
+                    setEmail(value);
+                    setIsEmailVerified(false);
+                    setVerifiedEmail('');
+                    setExpireAt(null);
+                  }}
                   keyboardType="email-address"
                   autoCapitalize="none"
                   autoCorrect={false}
@@ -112,12 +201,38 @@ export default function RegisterPage() {
                 {/* 이메일 인증하기 버튼 — 입력 필드 우측 */}
                 <TouchableOpacity
                   onPress={handleOpenVerifyModal}
+                  disabled={sendEmailCodeMutation.isPending}
                   className="ml-2 rounded-full px-3 py-1"
-                  style={{ backgroundColor: COLORS.primary }}>
-                  <Text className="text-xs font-semibold text-white">이메일 인증</Text>
+                  style={{
+                    backgroundColor: sendEmailCodeMutation.isPending ? '#A3A3A3' : COLORS.primary,
+                  }}>
+                  <Text className="text-xs font-semibold text-white">
+                    {sendEmailCodeMutation.isPending ? '전송 중' : '이메일 인증'}
+                  </Text>
                 </TouchableOpacity>
               </View>
             </View>
+
+            {isEmailVerified && verifiedEmail === email.trim() && (
+              // 검증한 이메일과 현재 입력값이 같을 때만 인증 완료로 표시합니다.
+              <Text className="mb-6 text-sm text-green-600">이메일 인증이 완료되었습니다.</Text>
+            )}
+
+            {sendEmailCodeMutation.isError && (
+              <Text className="mb-6 text-sm text-red-500">
+                {sendEmailCodeMutation.error instanceof Error
+                  ? sendEmailCodeMutation.error.message
+                  : '인증 메일 발송에 실패했습니다.'}
+              </Text>
+            )}
+
+            {verifyEmailCodeMutation.isError && (
+              <Text className="mb-6 text-sm text-red-500">
+                {verifyEmailCodeMutation.error instanceof Error
+                  ? verifyEmailCodeMutation.error.message
+                  : '이메일 인증에 실패했습니다.'}
+              </Text>
+            )}
 
             {/* 비밀번호 입력 */}
             <View className="mb-6">
@@ -157,12 +272,23 @@ export default function RegisterPage() {
               </View>
             </View>
 
+            {signupMutation.isError && (
+              <Text className="mb-6 text-sm text-red-500">
+                {signupMutation.error instanceof Error
+                  ? signupMutation.error.message
+                  : '회원가입에 실패했습니다.'}
+              </Text>
+            )}
+
             {/* 회원가입 버튼 */}
             <TouchableOpacity
               onPress={handleRegister}
+              disabled={isRegisterDisabled}
               className="items-center rounded-full py-4"
-              style={{ backgroundColor: COLORS.primary }}>
-              <Text className="text-base font-semibold text-white">회원가입</Text>
+              style={{ backgroundColor: isRegisterDisabled ? '#A3A3A3' : COLORS.primary }}>
+              <Text className="text-base font-semibold text-white">
+                {signupMutation.isPending ? '회원가입 중...' : '회원가입'}
+              </Text>
             </TouchableOpacity>
           </View>
         </ScrollView>
@@ -173,10 +299,9 @@ export default function RegisterPage() {
         visible={isVerifyModalVisible}
         onClose={() => setIsVerifyModalVisible(false)}
         onVerifyComplete={handleVerifyComplete}
-        onResend={() => {
-          // [TODO] 인증 코드 재발송 API 호출
-          console.log('인증 번호 재전송');
-        }}
+        onResend={handleOpenVerifyModal}
+        remainingSeconds={remainingSeconds}
+        isSubmitting={verifyEmailCodeMutation.isPending}
       />
     </SafeAreaView>
   );

--- a/components/modals/EmailVerifyModal.tsx
+++ b/components/modals/EmailVerifyModal.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Modal, Pressable, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { COLORS } from '../../constants/theme';
 
-// 인증 코드 자릿수
+// 백엔드 명세 기준 6자리 코드를 입력받습니다.
 const CODE_LENGTH = 6;
 
 interface EmailVerifyModalProps {
@@ -10,10 +10,14 @@ interface EmailVerifyModalProps {
   visible: boolean;
   /** 모달 닫기 콜백 */
   onClose: () => void;
-  /** 로그인 완료 버튼 콜백 (API 연동 전까지 단순 콜백) */
-  onVerifyComplete: () => void;
-  /** [TODO] 인증 코드 재전송 콜백 */
+  /** 인증 완료 버튼 콜백 */
+  onVerifyComplete: (code: string) => void;
+  /** 인증 번호 재전송 콜백 */
   onResend?: () => void;
+  /** 남은 인증 유효 시간(초) */
+  remainingSeconds: number;
+  /** 인증 중 여부 */
+  isSubmitting?: boolean;
 }
 
 /**
@@ -32,17 +36,25 @@ export default function EmailVerifyModal({
   onClose,
   onVerifyComplete,
   onResend,
+  remainingSeconds,
+  isSubmitting = false,
 }: EmailVerifyModalProps) {
   const [code, setCode] = useState<string[]>(Array(CODE_LENGTH).fill(''));
   const inputRefs = useRef<(TextInput | null)[]>(Array(CODE_LENGTH).fill(null));
 
-  // 모달이 닫힐 때 코드 초기화
+  useEffect(() => {
+    if (!visible) {
+      setCode(Array(CODE_LENGTH).fill(''));
+    }
+  }, [visible]);
+
+  // 모달 종료 시 입력값을 비워 다음 인증 요청과 섞이지 않게 합니다.
   const handleClose = () => {
     setCode(Array(CODE_LENGTH).fill(''));
     onClose();
   };
 
-  // 숫자 입력: 다음 칸으로 자동 포커스 이동
+  // 한 자리씩 입력하고 다음 칸으로 이동합니다.
   const handleCodeChange = (text: string, index: number) => {
     const digit = text.replace(/[^0-9]/g, '').slice(-1);
     const newCode = [...code];
@@ -54,24 +66,36 @@ export default function EmailVerifyModal({
     }
   };
 
-  // 백스페이스: 현재 칸이 비어있으면 이전 칸으로 포커스 복귀
+  // 빈 칸에서 백스페이스를 누르면 이전 칸으로 이동합니다.
   const handleCodeKeyPress = (key: string, index: number) => {
     if (key === 'Backspace' && !code[index] && index > 0) {
       inputRefs.current[index - 1]?.focus();
     }
   };
 
-  // 인증 번호 재전송: 코드 초기화 후 첫 번째 칸 포커스
+  // 재전송 시 입력값을 초기화하고 첫 칸부터 다시 입력받습니다.
   const handleResend = () => {
     setCode(Array(CODE_LENGTH).fill(''));
     inputRefs.current[0]?.focus();
     onResend?.();
   };
 
-  // 로그인 완료 버튼
+  // 만료 전 6자리가 모두 입력된 경우에만 인증을 시도합니다.
   const handleVerifyComplete = () => {
-    setCode(Array(CODE_LENGTH).fill(''));
-    onVerifyComplete();
+    const joinedCode = code.join('');
+
+    if (joinedCode.length !== CODE_LENGTH || remainingSeconds <= 0) {
+      return;
+    }
+
+    onVerifyComplete(joinedCode);
+  };
+
+  const formatRemainingTime = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+
+    return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
   };
 
   return (
@@ -108,7 +132,7 @@ export default function EmailVerifyModal({
 
           {/* 안내 문구 */}
           <Text style={{ fontSize: 13, color: '#6B7280', lineHeight: 20, marginBottom: 24 }}>
-            {'로그인 보호를 위해 이메일로 전송된 6자리 인증\n코드를 입력해 주세요.'}
+            {'회원가입을 위해 이메일로 전송된 6자리 인증\n코드를 입력해 주세요.'}
           </Text>
 
           {/* 6자리 코드 입력 박스 */}
@@ -150,15 +174,23 @@ export default function EmailVerifyModal({
               ))}
           </View>
 
-          {/* 재전송 안내 */}
+          {/* 남은 시간과 재전송 액션을 함께 표시합니다. */}
           <View
             style={{
               flexDirection: 'row',
               justifyContent: 'center',
               alignItems: 'center',
-              gap: 4,
+              gap: 8,
               marginBottom: 24,
             }}>
+            <Text
+              style={{
+                fontSize: 12,
+                fontWeight: '600',
+                color: remainingSeconds > 0 ? '#111827' : '#DC2626',
+              }}>
+              {remainingSeconds > 0 ? formatRemainingTime(remainingSeconds) : '인증 만료'}
+            </Text>
             <Text style={{ fontSize: 12, color: '#9CA3AF' }}>인증 번호를 받지 못하셨나요?</Text>
             <TouchableOpacity onPress={handleResend}>
               <Text style={{ fontSize: 12, fontWeight: '600', color: COLORS.primary }}>
@@ -167,18 +199,20 @@ export default function EmailVerifyModal({
             </TouchableOpacity>
           </View>
 
-          {/* 로그인 완료 버튼 */}
-          {/* [TODO] 6자리 코드 검증 API 호출 후 성공 시 onVerifyComplete 실행 */}
+          {/* 실제 검증 요청은 부모 화면에서 수행합니다. */}
           <TouchableOpacity
             onPress={handleVerifyComplete}
+            disabled={isSubmitting || remainingSeconds <= 0}
             style={{
-              backgroundColor: COLORS.primary,
+              backgroundColor: isSubmitting || remainingSeconds <= 0 ? '#A3A3A3' : COLORS.primary,
               borderRadius: 999,
               paddingVertical: 16,
               alignItems: 'center',
               marginBottom: 12,
             }}>
-            <Text style={{ color: 'white', fontSize: 16, fontWeight: '600' }}>로그인 완료</Text>
+            <Text style={{ color: 'white', fontSize: 16, fontWeight: '600' }}>
+              {isSubmitting ? '인증 중...' : '이메일 인증 완료'}
+            </Text>
           </TouchableOpacity>
 
           {/* 취소 버튼 */}

--- a/components/modals/EmailVerifyModal.tsx
+++ b/components/modals/EmailVerifyModal.tsx
@@ -48,9 +48,8 @@ export default function EmailVerifyModal({
     }
   }, [visible]);
 
-  // 모달 종료 시 입력값을 비워 다음 인증 요청과 섞이지 않게 합니다.
+  // visible 변화에 맞춰 초기화되므로 닫기 함수는 부모 상태만 변경합니다.
   const handleClose = () => {
-    setCode(Array(CODE_LENGTH).fill(''));
     onClose();
   };
 

--- a/hooks/auth/useLoginMutation.ts
+++ b/hooks/auth/useLoginMutation.ts
@@ -1,0 +1,72 @@
+import { useMutation } from '@tanstack/react-query';
+import { loginApi } from '../../api/auth';
+import { setRefreshToken } from '../../lib/secureStore';
+import { useAuthActions } from '../../store/useAuthStore';
+
+function readStringCandidate(source: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = source[key];
+
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function readNumberCandidate(source: Record<string, unknown>, keys: string[]) {
+  for (const key of keys) {
+    const value = source[key];
+
+    if (typeof value === 'number') {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export function useLoginMutation() {
+  const { setSession } = useAuthActions();
+
+  return useMutation({
+    mutationFn: loginApi,
+    onSuccess: async (response) => {
+      const responseRecord = response as Record<string, unknown>;
+      const nestedData =
+        responseRecord.data && typeof responseRecord.data === 'object'
+          ? (responseRecord.data as Record<string, unknown>)
+          : null;
+
+      // Swagger 응답과 실제 응답 키가 다를 수 있어 여러 후보를 순서대로 확인합니다.
+      const accessToken =
+        (nestedData && readStringCandidate(nestedData, ['accessToken', 'access_token'])) ??
+        readStringCandidate(responseRecord, ['accessToken', 'access_token']);
+
+      const refreshToken =
+        (nestedData && readStringCandidate(nestedData, ['refreshToken', 'refresh_token'])) ??
+        readStringCandidate(responseRecord, ['refreshToken', 'refresh_token']);
+
+      const userId =
+        (nestedData && readNumberCandidate(nestedData, ['userId', 'user_id'])) ??
+        readNumberCandidate(responseRecord, ['userId', 'user_id']) ??
+        0;
+
+      // 토큰 형식이 맞지 않으면 저장 전에 명확한 에러로 중단합니다.
+      if (!accessToken) {
+        console.log('invalid login accessToken', response);
+        throw new Error('로그인 응답의 accessToken 형식이 올바르지 않습니다.');
+      }
+
+      if (!refreshToken) {
+        console.log('invalid login refreshToken', response);
+        throw new Error('로그인 응답의 refreshToken 형식이 올바르지 않습니다.');
+      }
+
+      // 로그인 성공 시 RT는 SecureStore, AT는 메모리 상태로 분리 저장합니다.
+      await setRefreshToken(refreshToken);
+      setSession({ userId, accessToken });
+    },
+  });
+}

--- a/hooks/auth/useLoginMutation.ts
+++ b/hooks/auth/useLoginMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { loginApi } from '../../api/auth';
-import { setRefreshToken } from '../../lib/secureStore';
+import { setRefreshToken, setStoredUserId } from '../../lib/secureStore';
 import { useAuthActions } from '../../store/useAuthStore';
 
 function readStringCandidate(source: Record<string, unknown>, keys: string[]) {
@@ -50,8 +50,7 @@ export function useLoginMutation() {
 
       const userId =
         (nestedData && readNumberCandidate(nestedData, ['userId', 'user_id'])) ??
-        readNumberCandidate(responseRecord, ['userId', 'user_id']) ??
-        0;
+        readNumberCandidate(responseRecord, ['userId', 'user_id']);
 
       // 토큰 형식이 맞지 않으면 저장 전에 명확한 에러로 중단합니다.
       if (!accessToken) {
@@ -64,8 +63,14 @@ export function useLoginMutation() {
         throw new Error('로그인 응답의 refreshToken 형식이 올바르지 않습니다.');
       }
 
+      if (typeof userId !== 'number') {
+        console.log('invalid login userId', response);
+        throw new Error('로그인 응답의 userId 형식이 올바르지 않습니다.');
+      }
+
       // 로그인 성공 시 RT는 SecureStore, AT는 메모리 상태로 분리 저장합니다.
       await setRefreshToken(refreshToken);
+      await setStoredUserId(userId);
       setSession({ userId, accessToken });
     },
   });

--- a/hooks/auth/useLogoutMutation.ts
+++ b/hooks/auth/useLogoutMutation.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { useAuthActions } from '../../store/useAuthStore';
+
+export function useLogoutMutation() {
+  const { logout } = useAuthActions();
+
+  return useMutation({
+    mutationFn: logout,
+  });
+}

--- a/hooks/auth/useSendEmailCodeMutation.ts
+++ b/hooks/auth/useSendEmailCodeMutation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { sendEmailCodeApi } from '../../api/auth';
+
+export function useSendEmailCodeMutation() {
+  return useMutation({
+    mutationFn: sendEmailCodeApi,
+  });
+}

--- a/hooks/auth/useSignupMutation.ts
+++ b/hooks/auth/useSignupMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { signupApi } from '../../api/auth';
+
+export function useSignupMutation() {
+  return useMutation({
+    // 회원가입은 완료 후 로그인 화면으로 보내므로 세션 저장을 하지 않습니다.
+    mutationFn: signupApi,
+  });
+}

--- a/hooks/auth/useVerifyEmailCodeMutation.ts
+++ b/hooks/auth/useVerifyEmailCodeMutation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { verifyEmailCodeApi } from '../../api/auth';
+
+export function useVerifyEmailCodeMutation() {
+  return useMutation({
+    mutationFn: verifyEmailCodeApi,
+  });
+}

--- a/lib/secureStore.ts
+++ b/lib/secureStore.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from 'expo-secure-store';
+
+const REFRESH_TOKEN_KEY = 'batchar_refresh_token';
+
+export async function setRefreshToken(refreshToken: string) {
+  await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
+}
+
+export async function getRefreshToken() {
+  return SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function removeRefreshToken() {
+  await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}

--- a/lib/secureStore.ts
+++ b/lib/secureStore.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 
 const REFRESH_TOKEN_KEY = 'batchar_refresh_token';
+const USER_ID_KEY = 'batchar_user_id';
 
 export async function setRefreshToken(refreshToken: string) {
   await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
@@ -12,4 +13,23 @@ export async function getRefreshToken() {
 
 export async function removeRefreshToken() {
   await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+}
+
+export async function setStoredUserId(userId: number) {
+  await SecureStore.setItemAsync(USER_ID_KEY, String(userId));
+}
+
+export async function getStoredUserId() {
+  const userId = await SecureStore.getItemAsync(USER_ID_KEY);
+
+  if (!userId) {
+    return null;
+  }
+
+  const parsedUserId = Number(userId);
+  return Number.isFinite(parsedUserId) ? parsedUserId : null;
+}
+
+export async function removeStoredUserId() {
+  await SecureStore.deleteItemAsync(USER_ID_KEY);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "~14.0.4",
+        "@tanstack/react-query": "^5.94.5",
         "expo": "~52.0.0",
         "expo-asset": "~11.0.0",
         "expo-constants": "~17.0.0",
         "expo-font": "~12.0.9",
         "expo-router": "~4.0.9",
+        "expo-secure-store": "^55.0.9",
         "expo-status-bar": "~2.0.0",
         "immer": "^11.1.3",
         "nativewind": "^2.0.11",
@@ -4152,6 +4154,32 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.94.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.94.5.tgz",
+      "integrity": "sha512-Vx1JJiBURW/wdNGP45afjrqn0LfxYwL7K/bSrQvNRtyLGF1bxQPgUXCpzscG29e+UeFOh9hz1KOVala0N+bZiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.94.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.94.5.tgz",
+      "integrity": "sha512-1wmrxKFkor+q8l+ygdHmv0Sq5g84Q3p4xvuJ7AdSIAhQQ7udOt+ZSZ19g1Jea3mHqtlTslLGJsmC4vHFgP0P3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.94.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -8261,6 +8289,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.9.tgz",
+      "integrity": "sha512-TIPGjM73LKlebpXwgAu/yL7lNWr6RQYmFw3vgYHOqLFYQMpsBqkQmopovbNX3c/0+RCE9KZlLAkcz8r6detILQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   },
   "dependencies": {
     "@expo/vector-icons": "~14.0.4",
+    "@tanstack/react-query": "^5.94.5",
     "expo": "~52.0.0",
     "expo-asset": "~11.0.0",
     "expo-constants": "~17.0.0",
     "expo-font": "~12.0.9",
     "expo-router": "~4.0.9",
+    "expo-secure-store": "^55.0.9",
     "expo-status-bar": "~2.0.0",
     "immer": "^11.1.3",
     "nativewind": "^2.0.11",

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -2,7 +2,13 @@ import { create } from 'zustand';
 import { combine, devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { logoutApi, refreshApi } from '../api/auth';
-import { getRefreshToken, removeRefreshToken, setRefreshToken } from '../lib/secureStore';
+import {
+  getRefreshToken,
+  getStoredUserId,
+  removeRefreshToken,
+  removeStoredUserId,
+  setRefreshToken,
+} from '../lib/secureStore';
 
 type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
 
@@ -42,10 +48,11 @@ const useAuthStore = create(
 
           initializeAuth: async () => {
             try {
-              // 앱 재실행 시에는 저장된 RT로 세션을 복구합니다.
+              // 앱 재실행 시에는 저장된 RT와 userId로 세션을 복구합니다.
               const refreshToken = await getRefreshToken();
+              const storedUserId = await getStoredUserId();
 
-              if (!refreshToken) {
+              if (!refreshToken || storedUserId === null) {
                 set((state) => {
                   state.userId = null;
                   state.accessToken = null;
@@ -62,7 +69,7 @@ const useAuthStore = create(
               await setRefreshToken(nextRefreshToken);
 
               set((state) => {
-                state.userId = null;
+                state.userId = storedUserId;
                 state.accessToken = accessToken;
                 state.status = 'authenticated';
                 state.isInitialized = true;
@@ -70,6 +77,7 @@ const useAuthStore = create(
             } catch {
               // 세션 복구에 실패하면 저장된 RT를 제거하고 비로그인 상태로 전환합니다.
               await removeRefreshToken();
+              await removeStoredUserId();
 
               set((state) => {
                 state.userId = null;
@@ -91,6 +99,7 @@ const useAuthStore = create(
               // 서버 응답과 무관하게 앱 쪽 세션은 반드시 종료합니다.
             } finally {
               await removeRefreshToken();
+              await removeStoredUserId();
 
               set((state) => {
                 state.userId = null;

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -6,7 +6,14 @@ import { getRefreshToken, removeRefreshToken, setRefreshToken } from '../lib/sec
 
 type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
 
-const initialState = {
+type AuthStoreState = {
+  userId: number | null;
+  accessToken: string | null;
+  status: AuthStatus;
+  isInitialized: boolean;
+};
+
+const initialState: AuthStoreState = {
   userId: null,
   accessToken: null,
   status: 'idle' as AuthStatus,

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -1,18 +1,17 @@
 import { create } from 'zustand';
-import { devtools, combine } from 'zustand/middleware';
+import { combine, devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
+import { logoutApi, refreshApi } from '../api/auth';
+import { getRefreshToken, removeRefreshToken, setRefreshToken } from '../lib/secureStore';
 
-// ──────────────────────────────────────────────────────────────────
-// [TODO] 실제 토큰 연동 시 아래 단계 적용:
-//  1. `persist` 미들웨어 추가 (zustand/middleware)
-//  2. storage: AsyncStorage (from @react-native-async-storage/async-storage)
-//  3. initialState에 token: string | null 필드 추가
-//  4. setToken / clearToken 액션 추가
-// ──────────────────────────────────────────────────────────────────
+type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
 
 const initialState = {
-  // 로그인 여부 — 토큰 구현 전 임시 boolean 플래그
-  isLoggedIn: false,
+  userId: null,
+  accessToken: null,
+  status: 'idle' as AuthStatus,
+  // 초기 세션 복원이 끝나기 전에는 라우팅을 보류합니다.
+  isInitialized: false,
 };
 
 const useAuthStore = create(
@@ -20,17 +19,79 @@ const useAuthStore = create(
     immer(
       combine(initialState, (set) => ({
         actions: {
-          // 로그인 처리 (추후 토큰 저장 로직 추가)
-          login: () =>
+          setSession: ({ userId, accessToken }: { userId: number; accessToken: string }) =>
             set((state) => {
-              state.isLoggedIn = true;
+              state.userId = userId;
+              state.accessToken = accessToken;
+              state.status = 'authenticated';
             }),
 
-          // 로그아웃 처리 (추후 토큰 삭제 로직 추가)
-          logout: () =>
+          clearSession: () =>
             set((state) => {
-              state.isLoggedIn = false;
+              state.userId = null;
+              state.accessToken = null;
+              state.status = 'unauthenticated';
             }),
+
+          initializeAuth: async () => {
+            try {
+              // 앱 재실행 시에는 저장된 RT로 세션을 복구합니다.
+              const refreshToken = await getRefreshToken();
+
+              if (!refreshToken) {
+                set((state) => {
+                  state.userId = null;
+                  state.accessToken = null;
+                  state.status = 'unauthenticated';
+                  state.isInitialized = true;
+                });
+                return;
+              }
+
+              const response = await refreshApi({ refreshToken });
+              const { accessToken, refreshToken: nextRefreshToken } = response.data;
+
+              // refresh 응답의 RT는 항상 최신 값으로 교체합니다.
+              await setRefreshToken(nextRefreshToken);
+
+              set((state) => {
+                state.userId = null;
+                state.accessToken = accessToken;
+                state.status = 'authenticated';
+                state.isInitialized = true;
+              });
+            } catch {
+              // 세션 복구에 실패하면 저장된 RT를 제거하고 비로그인 상태로 전환합니다.
+              await removeRefreshToken();
+
+              set((state) => {
+                state.userId = null;
+                state.accessToken = null;
+                state.status = 'unauthenticated';
+                state.isInitialized = true;
+              });
+            }
+          },
+
+          logout: async () => {
+            try {
+              const refreshToken = await getRefreshToken();
+
+              if (refreshToken) {
+                await logoutApi({ refreshToken });
+              }
+            } catch {
+              // 서버 응답과 무관하게 앱 쪽 세션은 반드시 종료합니다.
+            } finally {
+              await removeRefreshToken();
+
+              set((state) => {
+                state.userId = null;
+                state.accessToken = null;
+                state.status = 'unauthenticated';
+              });
+            }
+          },
         },
       }))
     ),
@@ -38,8 +99,10 @@ const useAuthStore = create(
   )
 );
 
-// 리렌더링 최적화를 위한 선택적 구독 커스텀 훅
-export const useIsLoggedIn = () => useAuthStore((state) => state.isLoggedIn);
+export default useAuthStore;
 
-// 액션 훅
+export const useAuthStatus = () => useAuthStore((state) => state.status);
+export const useAccessToken = () => useAuthStore((state) => state.accessToken);
+export const useIsInitialized = () => useAuthStore((state) => state.isInitialized);
+export const useIsLoggedIn = () => useAuthStore((state) => state.status === 'authenticated');
 export const useAuthActions = () => useAuthStore((state) => state.actions);


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 로그인/회원가입 관련 화면을 실제 백엔드 API와 연동하고, 토큰 기반 인증 상태 관리 로직을 구현하였습니다.

## 📝 변경 사항 요약 (Summary)

- 로그인, 회원가입, 이메일 인증번호 발송/검증, 토큰 재발급, 로그아웃 API 계층 추가
- TanStack Query 기반 인증 mutation 훅 구성
- accessToken은 zustand, refreshToken은 SecureStore에 저장하도록 인증 상태 구조 개편
- 앱 시작 시 refreshToken으로 세션 복구하도록 auth store 및 route guard 수정
- 로그인 화면을 실제 API 기반 로그인 흐름으로 연결
- 이메일 인증 모달 버튼 문구를 "이메일 인증 완료"로 변경하고 10분 타이머 및 재전송 기능 추가
- 응답 구조 차이를 고려해 로그인 토큰 파싱 로직을 유연하게 보강

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #22 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## ➕ 추가 정보 (Additional Information)

- [로그인/회원가입 API 연동 문서](https://general-biplane-e1e.notion.site/API-32bd858c2baa80ffbab3e4e5a659c5ce?source=copy_link)