### PR TITLE
#34 feature(register): 회원가입 닉네임 UI 및 중복 검사 기능 추가

### DIFF
--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from './client';
 import type {
+  CheckNicknameDuplicateResponse,
   LoginRequest,
   LoginResponse,
   LogoutRequest,
@@ -8,6 +9,7 @@ import type {
   RefreshResponse,
   SendEmailCodeRequest,
   SendEmailCodeResponse,
+  CheckNicknameDuplicateRequest,
   SignupRequest,
   SignupResponse,
   VerifyEmailCodeRequest,
@@ -26,6 +28,17 @@ export function signupApi(body: SignupRequest) {
     method: 'POST',
     body: JSON.stringify(body),
   });
+}
+
+export function checkNicknameDuplicateApi({ name }: CheckNicknameDuplicateRequest) {
+  const searchParams = new URLSearchParams({ name });
+
+  return apiFetch<CheckNicknameDuplicateResponse>(
+    `/api/users/name/duplicate?${searchParams.toString()}`,
+    {
+      method: 'GET',
+    }
+  );
 }
 
 export function sendEmailCodeApi(body: SendEmailCodeRequest) {

--- a/api/types.ts
+++ b/api/types.ts
@@ -15,6 +15,10 @@ export type SignupRequest = {
   address: string;
 };
 
+export type CheckNicknameDuplicateRequest = {
+  name: string;
+};
+
 export type SendEmailCodeRequest = {
   email: string;
 };
@@ -47,6 +51,7 @@ export type RefreshResponse = ApiResponse<{
 }>;
 
 export type SendEmailCodeResponse = ApiResponse<string>;
+export type CheckNicknameDuplicateResponse = ApiResponse<null>;
 
 export type VerifyEmailCodeResponse = ApiResponse<{
   email: string;

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -11,8 +11,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
-import { COLORS, INPUT_STYLE, LAYOUT } from '../constants/theme';
+import { COLORS, INPUT_STYLE } from '../constants/theme';
 import EmailVerifyModal from '../components/modals/EmailVerifyModal';
+import { useCheckNicknameDuplicateMutation } from '../hooks/auth/useCheckNicknameDuplicateMutation';
 import { useSendEmailCodeMutation } from '../hooks/auth/useSendEmailCodeMutation';
 import { useSignupMutation } from '../hooks/auth/useSignupMutation';
 import { useVerifyEmailCodeMutation } from '../hooks/auth/useVerifyEmailCodeMutation';
@@ -26,12 +27,15 @@ export default function RegisterPage() {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [name, setName] = useState('');
   const [address, setAddress] = useState('');
+  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
+  const [checkedNickname, setCheckedNickname] = useState('');
   const [isVerifyModalVisible, setIsVerifyModalVisible] = useState(false);
   const [isEmailVerified, setIsEmailVerified] = useState(false);
   const [verifiedEmail, setVerifiedEmail] = useState('');
   const [expireAt, setExpireAt] = useState<number | null>(null);
   const [now, setNow] = useState(Date.now());
 
+  const checkNicknameDuplicateMutation = useCheckNicknameDuplicateMutation();
   const sendEmailCodeMutation = useSendEmailCodeMutation();
   const verifyEmailCodeMutation = useVerifyEmailCodeMutation();
   const signupMutation = useSignupMutation();
@@ -86,6 +90,24 @@ export default function RegisterPage() {
     );
   };
 
+  const handleCheckNickname = () => {
+    const normalizedNickname = name.trim();
+
+    if (!normalizedNickname) {
+      return;
+    }
+
+    checkNicknameDuplicateMutation.mutate(
+      { name: normalizedNickname },
+      {
+        onSuccess: () => {
+          setIsNicknameChecked(true);
+          setCheckedNickname(normalizedNickname);
+        },
+      }
+    );
+  };
+
   const handleVerifyComplete = (code: string) => {
     const normalizedEmail = email.trim();
 
@@ -130,6 +152,8 @@ export default function RegisterPage() {
     !password.trim() ||
     !name.trim() ||
     !address.trim() ||
+    !isNicknameChecked ||
+    checkedNickname !== name.trim() ||
     !isEmailVerified ||
     verifiedEmail !== email.trim() ||
     signupMutation.isPending;
@@ -162,22 +186,51 @@ export default function RegisterPage() {
             {/* 타이틀 */}
             <Text className="mb-6 text-xl font-bold text-gray-900">회원가입</Text>
 
-            {/* 이름 입력 */}
+            {/* 닉네임 입력 */}
             <View className="mb-6">
-              <Text className="mb-2 text-sm font-medium text-gray-700">이름</Text>
-              <View className="border-b border-gray-300">
+              <Text className="mb-2 text-sm font-medium text-gray-700">닉네임</Text>
+              <View className="flex-row items-center border-b border-gray-300">
                 <TextInput
-                  className="text-base text-gray-900"
-                  placeholder="이름을 입력해주세요"
+                  className="flex-1 text-base text-gray-900"
+                  placeholder="닉네임을 입력해주세요"
                   placeholderTextColor="#9CA3AF"
                   value={name}
-                  onChangeText={setName}
+                  onChangeText={(value) => {
+                    setName(value);
+                    setIsNicknameChecked(false);
+                    setCheckedNickname('');
+                  }}
                   autoCapitalize="none"
                   autoCorrect={false}
                   style={INPUT_STYLE}
                 />
+                <TouchableOpacity
+                  onPress={handleCheckNickname}
+                  disabled={checkNicknameDuplicateMutation.isPending}
+                  className="ml-2 rounded-full px-3 py-1"
+                  style={{
+                    backgroundColor: checkNicknameDuplicateMutation.isPending
+                      ? '#A3A3A3'
+                      : COLORS.primary,
+                  }}>
+                  <Text className="text-xs font-semibold text-white">
+                    {checkNicknameDuplicateMutation.isPending ? '검사 중' : '중복 검사'}
+                  </Text>
+                </TouchableOpacity>
               </View>
             </View>
+
+            {isNicknameChecked && checkedNickname === name.trim() && (
+              <Text className="mb-6 text-sm text-green-600">사용 가능한 닉네임입니다.</Text>
+            )}
+
+            {checkNicknameDuplicateMutation.isError && (
+              <Text className="mb-6 text-sm text-red-500">
+                {checkNicknameDuplicateMutation.error instanceof Error
+                  ? checkNicknameDuplicateMutation.error.message
+                  : '닉네임 중복 검사에 실패했습니다.'}
+              </Text>
+            )}
 
             {/* 이메일 입력 */}
             <View className="mb-6">
@@ -206,7 +259,6 @@ export default function RegisterPage() {
                   disabled={sendEmailCodeMutation.isPending}
                   className="ml-2 rounded-full px-3 py-1"
                   style={{
-                    minHeight: LAYOUT.touchTargetMinHeight,
                     backgroundColor: sendEmailCodeMutation.isPending ? '#A3A3A3' : COLORS.primary,
                   }}>
                   <Text className="text-xs font-semibold text-white">
@@ -254,7 +306,6 @@ export default function RegisterPage() {
                 />
                 <TouchableOpacity
                   onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                  style={{ minHeight: LAYOUT.touchTargetMinHeight }}
                   className="items-center justify-center p-1">
                   <Feather name={isPasswordVisible ? 'eye' : 'eye-off'} size={20} color="#9CA3AF" />
                 </TouchableOpacity>

--- a/hooks/auth/useCheckNicknameDuplicateMutation.ts
+++ b/hooks/auth/useCheckNicknameDuplicateMutation.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { checkNicknameDuplicateApi } from '../../api/auth';
+
+export function useCheckNicknameDuplicateMutation() {
+  return useMutation({
+    mutationFn: checkNicknameDuplicateApi,
+  });
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 회원가입 닉네임 UI 및 중복 검사 기능 추가

## 📝 변경 사항 요약 (Summary)

- 회원가입 화면의 이름 표시 문구를 닉네임으로 변경
- 닉네임 중복 검사 API, mutation 훅 추가
- 닉네임 중복 검사 완료 전에는 회원가입이 불가능하도록 조건 추가
- 닉네임이 변경되면 기존 중복 검사 상태를 초기화하도록 처리
- 사용 가능한 닉네임 및 검사 실패 메시지 표시 추가

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #34 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)