### PR TITLE
#41 feature(wishlist): 찜 목록 조회/등록/취소 API 연동 및 낙관적 업데이트 적용

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -128,6 +128,34 @@ export type ProductDetail = {
 
 export type ProductDetailResponse = ApiResponse<ProductDetail>;
 
+// ── Wish ──
+
+export type WishSummary = {
+  wish_id: number;
+  product_id: number;
+  title: string;
+  category: string;
+  current_price: number;
+  end_time: string;
+  media_url: string;
+  wished_at: string;
+};
+
+export type WishListParams = {
+  page?: number;
+  size?: number;
+};
+
+export type WishListResponse = ApiResponse<{
+  content: WishSummary[];
+  has_next: boolean;
+}>;
+
+export type WishAddResponse = ApiResponse<{ wish_id: number }>;
+export type WishRemoveResponse = ApiResponse<null>;
+
+// ── Product Update/Delete ──
+
 export type ProductUpdateRequest = {
   title?: string;
   description?: string;

--- a/api/wish.ts
+++ b/api/wish.ts
@@ -1,0 +1,33 @@
+import { apiFetch } from './client';
+import { WishAddResponse, WishListParams, WishListResponse, WishRemoveResponse } from './types';
+
+export async function getWishlistApi(
+  params: WishListParams = {},
+  accessToken: string
+): Promise<WishListResponse> {
+  const query = new URLSearchParams();
+  if (params.page !== undefined) query.set('page', String(params.page));
+  if (params.size !== undefined) query.set('size', String(params.size));
+
+  const queryString = query.toString();
+  const path = `/api/wishes${queryString ? `?${queryString}` : ''}`;
+
+  return apiFetch<WishListResponse>(path, { accessToken });
+}
+
+export async function addWishApi(productId: number, accessToken: string): Promise<WishAddResponse> {
+  return apiFetch<WishAddResponse>(`/api/wishes/${productId}`, {
+    method: 'POST',
+    accessToken,
+  });
+}
+
+export async function removeWishApi(
+  productId: number,
+  accessToken: string
+): Promise<WishRemoveResponse> {
+  return apiFetch<WishRemoveResponse>(`/api/wishes/${productId}`, {
+    method: 'DELETE',
+    accessToken,
+  });
+}

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -15,6 +15,7 @@ import { useProductDetailQuery } from '../../hooks/product/useProductDetailQuery
 import { COLORS, LAYOUT } from '../../constants/theme';
 import { formatPrice } from '../../utils/format';
 import useAuthStore from '../../store/useAuthStore';
+import { useToggleWishMutation } from '../../hooks/wish/useToggleWishMutation';
 
 function formatRemainingTime(endTimeStr: string): string {
   const end = new Date(endTimeStr);
@@ -68,6 +69,7 @@ export default function ProductDetail() {
   const productId = Number(id) || 0;
   const userId = useAuthStore((state) => state.userId);
   const { data: product, isLoading, isError } = useProductDetailQuery(productId);
+  const { mutate: toggleWish } = useToggleWishMutation();
 
   if (isLoading) {
     return (
@@ -165,7 +167,9 @@ export default function ProductDetail() {
         {/* 상품 제목 */}
         <View className="flex-row items-start justify-between bg-white px-4 pb-4 pt-2">
           <Text className="flex-1 text-xl font-bold text-gray-900">{product.title}</Text>
-          <TouchableOpacity className="ml-2 pt-1">
+          <TouchableOpacity
+            className="ml-2 pt-1"
+            onPress={() => toggleWish({ productId, isWished: !!product.is_wished })}>
             <MaterialCommunityIcons
               name={product.is_wished ? 'heart' : 'heart-outline'}
               size={24}
@@ -313,7 +317,9 @@ export default function ProductDetail() {
 
       {/* 하단 버튼 */}
       <View className="flex-row items-center border-t border-gray-100 bg-white px-4 py-3">
-        <TouchableOpacity className="mr-4 p-1">
+        <TouchableOpacity
+          className="mr-4 p-1"
+          onPress={() => toggleWish({ productId, isWished: !!product.is_wished })}>
           <MaterialCommunityIcons
             name={product.is_wished ? 'heart' : 'heart-outline'}
             size={28}

--- a/app/wishlist.tsx
+++ b/app/wishlist.tsx
@@ -1,33 +1,33 @@
-import { View, Text, FlatList, TouchableOpacity } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { useMemo } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import TabBar from '../components/layout/TabBar';
 import WishlistProduct from '../components/product/WishlistProduct';
-import { MOCK_PRODUCTS } from '../mocks/product';
-import type { ProductData } from '../mocks/product';
+import { useWishlistQuery } from '../hooks/wish/useWishlistQuery';
+import { useToggleWishMutation } from '../hooks/wish/useToggleWishMutation';
 import { COLORS } from '../constants/theme';
+import type { WishSummary } from '../api/types';
 
 export default function Wishlist() {
   const router = useRouter();
+  const { data, isLoading, isError } = useWishlistQuery({ size: 50 });
+  const { mutate: toggleWish } = useToggleWishMutation();
 
-  // isFavorite가 true인 상품만 필터링 (메모이제이션)
-  const favoriteProducts = useMemo(() => MOCK_PRODUCTS.filter((p) => p.isFavorite), []);
+  const handleWishRemove = (productId: number) => {
+    toggleWish({ productId, isWished: true });
+  };
 
-  const renderItem = ({ item }: { item: ProductData }) => (
+  const renderItem = ({ item }: { item: WishSummary }) => (
     <WishlistProduct
-      id={item.id}
+      productId={item.product_id}
       title={item.title}
-      currentPrice={item.currentPrice}
-      participants={item.participants}
-      image={item.image}
-      badge={item.badge}
-      deadline={item.deadline}
-      likes={item.likes}
-      comments={item.comments}
-      onPress={() => router.push(`/product/${item.id}`)}
-      onFavoritePress={() => console.log('찜 해제:', item.title)}
+      currentPrice={item.current_price}
+      category={item.category}
+      endTime={item.end_time}
+      image={item.media_url}
+      onPress={() => router.push(`/product/${item.product_id}`)}
+      onWishRemove={() => handleWishRemove(item.product_id)}
     />
   );
 
@@ -42,14 +42,28 @@ export default function Wishlist() {
       </View>
 
       {/* 관심 상품 목록 */}
-      <FlatList
-        data={favoriteProducts}
-        renderItem={renderItem}
-        keyExtractor={(item) => item.id}
-        className="flex-1 bg-gray-50 px-4"
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ paddingVertical: 12 }}
-      />
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color={COLORS.active} />
+        </View>
+      ) : isError ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-sm text-gray-500">관심목록을 불러올 수 없습니다.</Text>
+        </View>
+      ) : !data?.content?.length ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-sm text-gray-500">찜한 상품이 없습니다.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={data.content}
+          renderItem={renderItem}
+          keyExtractor={(item) => String(item.wish_id)}
+          className="flex-1 bg-gray-50 px-4"
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingVertical: 12 }}
+        />
+      )}
 
       {/* 하단 탭바 */}
       <TabBar />

--- a/components/product/Product.tsx
+++ b/components/product/Product.tsx
@@ -12,10 +12,24 @@ interface ProductProps {
   participants: number;
   image: string;
   badge?: 'HOT' | 'NEW';
+  endTime?: string;
   deadline?: string;
   isFavorite?: boolean;
   onPress?: () => void;
   onFavoritePress?: () => void;
+}
+
+function formatRemainingTime(endTimeStr: string): string {
+  const end = new Date(endTimeStr);
+  const now = new Date();
+  const diff = end.getTime() - now.getTime();
+  if (diff <= 0) return '마감됨';
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  if (days > 0) return `${days}일 ${hours}시간`;
+  if (hours > 0) return `${hours}시간 ${minutes}분`;
+  return `${minutes}분`;
 }
 
 export default function Product({
@@ -26,6 +40,7 @@ export default function Product({
   participants,
   image,
   badge,
+  endTime,
   deadline,
   isFavorite = false,
   onPress,
@@ -64,14 +79,10 @@ export default function Product({
             ellipsizeMode="tail">
             {title.length > 10 ? `${title.substring(0, 10)}...` : title}
           </Text>
-          {location ? (
+          {endTime ? (
             <View className="mb-3 flex-row items-center">
-              <MaterialCommunityIcons
-                name="map-marker-outline"
-                size={12}
-                color={COLORS.textMuted}
-              />
-              <Text className="ml-1 text-xs text-gray-500">{location}</Text>
+              <MaterialCommunityIcons name="clock-outline" size={12} color={COLORS.textMuted} />
+              <Text className="ml-1 text-xs text-gray-500">{formatRemainingTime(endTime)}</Text>
             </View>
           ) : (
             <View className="mb-3" style={{ height: 16 }} />

--- a/components/product/ProductList.tsx
+++ b/components/product/ProductList.tsx
@@ -1,12 +1,24 @@
 import { View, Text, ActivityIndicator } from 'react-native';
+import { useMemo } from 'react';
 import { useRouter } from 'expo-router';
 import Product from './Product';
 import { useProductsQuery } from '../../hooks/product/useProductsQuery';
+import { useWishlistQuery } from '../../hooks/wish/useWishlistQuery';
+import { useToggleWishMutation } from '../../hooks/wish/useToggleWishMutation';
 import { COLORS } from '../../constants/theme';
 
 export default function ProductList() {
   const router = useRouter();
   const { data, isLoading, isError } = useProductsQuery();
+  const { data: wishlistData } = useWishlistQuery({ size: 100 });
+  const { mutate: toggleWish } = useToggleWishMutation();
+
+  // 찜한 상품 ID Set으로 변환하여 O(1) 조회
+  const wishedProductIds = useMemo(() => {
+    const ids = new Set<number>();
+    wishlistData?.content?.forEach((w) => ids.add(w.product_id));
+    return ids;
+  }, [wishlistData]);
 
   if (isLoading) {
     return (
@@ -36,20 +48,25 @@ export default function ProductList() {
 
   return (
     <View className="py-2">
-      {products.map((product) => (
-        <Product
-          key={String(product.product_id)}
-          id={String(product.product_id)}
-          title={product.title}
-          originalPrice={product.current_price}
-          currentPrice={product.current_price}
-          location=""
-          participants={product.bid_count}
-          image={product.media_url}
-          onPress={() => router.push(`/product/${product.product_id}`)}
-          onFavoritePress={() => console.log('찜 클릭:', product.title)}
-        />
-      ))}
+      {products.map((product) => {
+        const isWished = wishedProductIds.has(product.product_id);
+        return (
+          <Product
+            key={String(product.product_id)}
+            id={String(product.product_id)}
+            title={product.title}
+            originalPrice={product.current_price}
+            currentPrice={product.current_price}
+            location=""
+            participants={product.bid_count}
+            image={product.media_url}
+            endTime={product.end_time}
+            isFavorite={isWished}
+            onPress={() => router.push(`/product/${product.product_id}`)}
+            onFavoritePress={() => toggleWish({ productId: product.product_id, isWished })}
+          />
+        );
+      })}
     </View>
   );
 }

--- a/components/product/WishlistProduct.tsx
+++ b/components/product/WishlistProduct.tsx
@@ -4,31 +4,38 @@ import { COLORS, SHADOWS } from '../../constants/theme';
 import { formatPrice } from '../../utils/format';
 
 interface WishlistProductProps {
-  id: string;
+  productId: number;
   title: string;
   currentPrice: number;
-  participants: number;
+  category: string;
+  endTime: string;
   image: string;
-  badge?: 'HOT' | 'NEW';
-  deadline?: string;
-  likes?: number;
-  comments?: number;
   onPress?: () => void;
-  onFavoritePress?: () => void;
+  onWishRemove?: () => void;
 }
 
 export default function WishlistProduct({
   title,
   currentPrice,
-  participants,
+  category,
+  endTime,
   image,
-  badge,
-  deadline,
-  likes = 0,
-  comments = 0,
   onPress,
-  onFavoritePress,
+  onWishRemove,
 }: WishlistProductProps) {
+  const formatRemainingTime = (endTimeStr: string): string => {
+    const end = new Date(endTimeStr);
+    const now = new Date();
+    const diff = end.getTime() - now.getTime();
+    if (diff <= 0) return '마감됨';
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    if (days > 0) return `${days}일 ${hours}시간`;
+    if (hours > 0) return `${hours}시간 ${minutes}분`;
+    return `${minutes}분`;
+  };
+
   return (
     <TouchableOpacity
       onPress={onPress}
@@ -37,20 +44,7 @@ export default function WishlistProduct({
       style={SHADOWS.cardSubtle}>
       <View className="flex-row">
         {/* 상품 이미지 */}
-        <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
-          {badge && (
-            <View
-              className="absolute left-1.5 top-1.5 z-10 rounded px-1.5 py-0.5"
-              style={{ backgroundColor: badge === 'HOT' ? '#F97316' : COLORS.primary }}>
-              <Text className="text-xs font-bold text-white">{badge}</Text>
-            </View>
-          )}
-          {deadline && (
-            <View className="absolute bottom-1.5 left-1.5 z-10 flex-row items-center rounded bg-black/70 px-1.5 py-0.5">
-              <MaterialCommunityIcons name="clock-outline" size={10} color="white" />
-              <Text className="ml-1 text-xs font-semibold text-white">{deadline}</Text>
-            </View>
-          )}
+        <View className="mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
           <Image source={{ uri: image }} className="h-full w-full" resizeMode="cover" />
         </View>
 
@@ -64,37 +58,24 @@ export default function WishlistProduct({
               ellipsizeMode="tail">
               {title}
             </Text>
-            <TouchableOpacity onPress={onFavoritePress} activeOpacity={0.7} className="ml-2">
+            <TouchableOpacity onPress={onWishRemove} activeOpacity={0.7} className="ml-2">
               <MaterialCommunityIcons name="heart" size={24} color={COLORS.primary} />
             </TouchableOpacity>
+          </View>
+
+          {/* 카테고리 */}
+          <Text className="text-xs text-gray-500">{category}</Text>
+
+          {/* 남은 시간 */}
+          <View className="flex-row items-center">
+            <MaterialCommunityIcons name="clock-outline" size={12} color={COLORS.textMuted} />
+            <Text className="ml-1 text-xs text-gray-500">{formatRemainingTime(endTime)}</Text>
           </View>
 
           {/* 가격 */}
           <Text className="text-base font-extrabold" style={{ color: COLORS.primary }}>
             {formatPrice(currentPrice)} 원
           </Text>
-
-          {/* 하단: 참여자 + 좋아요/댓글 */}
-          <View className="flex-row items-center justify-between">
-            <View className="flex-row items-center">
-              <MaterialCommunityIcons
-                name="account-group-outline"
-                size={14}
-                color={COLORS.textMuted}
-              />
-              <Text className="ml-1 text-xs text-gray-400">{participants}명 참여중</Text>
-            </View>
-            <View className="flex-row items-center">
-              <View className="flex-row items-center">
-                <MaterialCommunityIcons name="heart-outline" size={14} color={COLORS.textMuted} />
-                <Text className="ml-0.5 text-xs text-gray-400">{likes}</Text>
-              </View>
-              <View className="ml-2 flex-row items-center">
-                <MaterialCommunityIcons name="chat-outline" size={14} color={COLORS.textMuted} />
-                <Text className="ml-0.5 text-xs text-gray-400">{comments}</Text>
-              </View>
-            </View>
-          </View>
         </View>
       </View>
     </TouchableOpacity>

--- a/hooks/wish/useToggleWishMutation.ts
+++ b/hooks/wish/useToggleWishMutation.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { addWishApi, removeWishApi } from '../../api/wish';
+import { ProductDetailResponse } from '../../api/types';
+import { useAccessToken } from '../../store/useAuthStore';
+
+type ToggleWishParams = {
+  productId: number;
+  isWished: boolean;
+};
+
+type ToggleWishContext = {
+  previousDetail?: ProductDetailResponse;
+};
+
+export function useToggleWishMutation() {
+  const accessToken = useAccessToken();
+  const queryClient = useQueryClient();
+
+  return useMutation<unknown, Error, ToggleWishParams, ToggleWishContext>({
+    mutationFn: async ({ productId, isWished }) => {
+      if (!accessToken) {
+        throw new Error('로그인이 필요합니다.');
+      }
+      if (isWished) {
+        return removeWishApi(productId, accessToken);
+      }
+      return addWishApi(productId, accessToken);
+    },
+
+    // 낙관적 업데이트: API 응답 전에 즉시 UI를 반영하여 사용자 체감 속도 향상
+    onMutate: async ({ productId, isWished }) => {
+      // 진행 중인 refetch를 취소하여 낙관적 업데이트가 덮어씌워지지 않도록 방지
+      await queryClient.cancelQueries({ queryKey: ['product', productId] });
+      await queryClient.cancelQueries({ queryKey: ['wishlist'] });
+
+      // 롤백을 위해 이전 상태 스냅샷 저장
+      const previousDetail = queryClient.getQueryData<ProductDetailResponse>([
+        'product',
+        productId,
+      ]);
+
+      // 캐시를 즉시 업데이트하여 하트 상태와 찜 수를 반영
+      if (previousDetail) {
+        queryClient.setQueryData<ProductDetailResponse>(['product', productId], {
+          ...previousDetail,
+          data: {
+            ...previousDetail.data,
+            is_wished: !isWished,
+            wish_count: previousDetail.data.wish_count + (isWished ? -1 : 1),
+          },
+        });
+      }
+
+      return { previousDetail };
+    },
+
+    // 에러 발생 시 스냅샷으로 롤백
+    onError: (_error, { productId }, context) => {
+      if (context?.previousDetail) {
+        queryClient.setQueryData(['product', productId], context.previousDetail);
+      }
+    },
+
+    // 성공/실패 여부와 관계없이 서버 데이터로 재동기화
+    onSettled: (_data, _error, { productId }) => {
+      queryClient.invalidateQueries({ queryKey: ['product', productId] });
+      queryClient.invalidateQueries({ queryKey: ['wishlist'] });
+      queryClient.invalidateQueries({ queryKey: ['products'] });
+    },
+  });
+}

--- a/hooks/wish/useWishlistQuery.ts
+++ b/hooks/wish/useWishlistQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getWishlistApi } from '../../api/wish';
+import { WishListParams } from '../../api/types';
+import { useAccessToken, useIsLoggedIn } from '../../store/useAuthStore';
+
+export function useWishlistQuery(params: WishListParams = {}) {
+  const accessToken = useAccessToken();
+  const isLoggedIn = useIsLoggedIn();
+
+  return useQuery({
+    queryKey: ['wishlist', params],
+    queryFn: () => getWishlistApi(params, accessToken!),
+    enabled: isLoggedIn && !!accessToken,
+    select: (response) => response.data,
+  });
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 찜 목록 조회, 등록, 취소 API 연동 및 낙관적 업데이트를 적용하였습니다.

## 📝 변경 사항 요약 (Summary)

- 찜 API 함수 추가
- useToggleWishMutation 훅 생성, 낙관적 업데이트로 즉시 UI 반영, 실패 시 롤백
- 찜 목록 조회 useWishlistQuery 훅 생성
- 상세 페이지 찜 API 연동
- 홈 페이지 상품 목록 찜 API 연동
- 상품 카드에 경매 남은 시간 표시 추가

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #41 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)