### PR TITLE
#49 fix(android): 모달 내부 버튼 및 오버레이 영역 터치 불가 현상 수정

### DIFF
--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -121,7 +121,7 @@ export default function ChatDetail() {
 
       <KeyboardAvoidingView
         className="flex-1"
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         keyboardVerticalOffset={0}>
         {/* 메시지 영역 */}
         <ScrollView

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -170,6 +170,7 @@ export default function ProductDetail() {
             ref={scrollViewRef}
             horizontal
             pagingEnabled
+            nestedScrollEnabled
             showsHorizontalScrollIndicator={false}
             onScroll={handleScroll}
             scrollEventThrottle={16}>
@@ -183,7 +184,10 @@ export default function ProductDetail() {
             ))}
           </ScrollView>
           {/* 페이지 인디케이터 */}
-          <View className="absolute bottom-4 right-4 rounded-full bg-black/60 px-3 py-1">
+          <View
+            pointerEvents="none"
+            className="absolute bottom-4 right-4 rounded-full px-3 py-1"
+            style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}>
             <Text className="text-sm font-medium text-white">
               {currentImageIndex + 1} / {images.length}
             </Text>
@@ -422,7 +426,7 @@ export default function ProductDetail() {
 
       {/* 입찰 모달 */}
       <Modal visible={bidModalVisible} transparent animationType="slide">
-        <View className="flex-1 justify-end bg-black/50">
+        <View className="flex-1 justify-end" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
           <View className="rounded-t-3xl bg-white px-5 pb-8 pt-6">
             <View className="mb-4 flex-row items-center justify-between">
               <Text className="text-lg font-bold text-gray-900">입찰하기</Text>

--- a/app/product/edit/[id].tsx
+++ b/app/product/edit/[id].tsx
@@ -317,7 +317,9 @@ export default function ProductEdit() {
                   <Image source={{ uri: media.url }} className="h-20 w-20 rounded-lg" />
                   <TouchableOpacity
                     onPress={() => handleRemoveExistingMedia(media.id)}
-                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full bg-black/70">
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full"
+                    style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}>
                     <MaterialCommunityIcons name="close" size={14} color="#FFFFFF" />
                   </TouchableOpacity>
                 </View>
@@ -328,7 +330,9 @@ export default function ProductEdit() {
                   <Image source={{ uri: img.uri }} className="h-20 w-20 rounded-lg" />
                   <TouchableOpacity
                     onPress={() => handleRemoveNewImage(index)}
-                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full bg-black/70">
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full"
+                    style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}>
                     <MaterialCommunityIcons name="close" size={14} color="#FFFFFF" />
                   </TouchableOpacity>
                 </View>
@@ -459,7 +463,8 @@ export default function ProductEdit() {
         <TouchableOpacity
           activeOpacity={1}
           onPress={() => setShowCategoryModal(false)}
-          className="flex-1 justify-end bg-black/40">
+          className="flex-1 justify-end"
+          style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
           <View className="rounded-t-2xl bg-white pb-8 pt-4">
             <Text className="mb-4 px-5 text-lg font-bold">카테고리 선택</Text>
             <FlatList
@@ -493,7 +498,8 @@ export default function ProductEdit() {
           <TouchableOpacity
             activeOpacity={1}
             onPress={() => setShowDatePicker(false)}
-            className="flex-1 justify-end bg-black/40">
+            className="flex-1 justify-end"
+            style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
             <View className="rounded-t-2xl bg-white pb-8 pt-4">
               <View className="mb-2 flex-row items-center justify-between px-5">
                 <TouchableOpacity onPress={() => setShowDatePicker(false)}>

--- a/app/productregister.tsx
+++ b/app/productregister.tsx
@@ -253,7 +253,9 @@ export default function Register() {
                   <Image source={{ uri: img.uri }} className="h-20 w-20 rounded-lg" />
                   <TouchableOpacity
                     onPress={() => handleRemoveImage(index)}
-                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full bg-black/70">
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    className="absolute -right-2 -top-2 h-5 w-5 items-center justify-center rounded-full"
+                    style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}>
                     <MaterialCommunityIcons name="close" size={14} color="#FFFFFF" />
                   </TouchableOpacity>
                 </View>
@@ -370,7 +372,8 @@ export default function Register() {
         <TouchableOpacity
           activeOpacity={1}
           onPress={() => setShowCategoryModal(false)}
-          className="flex-1 justify-end bg-black/40">
+          className="flex-1 justify-end"
+          style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
           <View className="rounded-t-2xl bg-white pb-8 pt-4">
             <Text className="mb-4 px-5 text-lg font-bold">카테고리 선택</Text>
             <FlatList
@@ -404,7 +407,8 @@ export default function Register() {
           <TouchableOpacity
             activeOpacity={1}
             onPress={() => setShowDatePicker(false)}
-            className="flex-1 justify-end bg-black/40">
+            className="flex-1 justify-end"
+            style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
             <View className="rounded-t-2xl bg-white pb-8 pt-4">
               <View className="mb-2 flex-row items-center justify-between px-5">
                 <TouchableOpacity onPress={() => setShowDatePicker(false)}>

--- a/app/wishlist.tsx
+++ b/app/wishlist.tsx
@@ -36,7 +36,9 @@ export default function Wishlist() {
       {/* 헤더 */}
       <View className="flex-row items-center justify-center bg-white px-5 py-4">
         <Text className="text-lg font-bold text-gray-900">관심목록</Text>
-        <TouchableOpacity className="absolute right-5">
+        <TouchableOpacity
+          className="absolute right-5"
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
           <MaterialCommunityIcons name="dots-horizontal" size={24} color={COLORS.text} />
         </TouchableOpacity>
       </View>

--- a/components/product/Product.tsx
+++ b/components/product/Product.tsx
@@ -57,13 +57,17 @@ export default function Product({
         <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
           {badge && (
             <View
+              pointerEvents="none"
               className={`absolute left-2 top-2 z-10 rounded px-1.5 py-1`}
               style={{ backgroundColor: badge === 'HOT' ? '#F97316' : COLORS.primary }}>
               <Text className="text-xs font-bold text-white">{badge}</Text>
             </View>
           )}
           {deadline && (
-            <View className="absolute bottom-2 left-2 z-10 flex-row items-center rounded bg-black/70 px-1.5 py-0.5">
+            <View
+              pointerEvents="none"
+              className="absolute bottom-2 left-2 z-10 flex-row items-center rounded px-1.5 py-0.5"
+              style={{ backgroundColor: 'rgba(0,0,0,0.7)' }}>
               <MaterialCommunityIcons name="clock-outline" size={10} color="white" />
               <Text className="ml-1 text-xs font-semibold text-white">{deadline}</Text>
             </View>


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 android 환경에서 모달 내부 버튼 및 오버레이 영역 터치 불가 현상을 수정하였습니다.


## 📝 변경 사항 요약 (Summary)

- 모달 반투명 배경을 NativeWind opacity 클래스에서 인라인 스타일로 교체
- 비터치 오버레이 요소에 pointerEvents="none" 추가
- 작은 터치 영역에 hitSlop 적용
- 중첩 ScrollView에 nestedScrollEnabled 추가
- 채팅 KeyboardAvoidingView Android behavior 설정

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #49 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)