### PR TITLE
#53 feature(bid): 경매 수동 마감 및 낙찰 API 연동, 입찰 확인 Alert 추가 및 import 경로 정리

### DIFF
--- a/api/product.ts
+++ b/api/product.ts
@@ -2,6 +2,7 @@ import * as FileSystem from 'expo-file-system/legacy';
 import { ImagePickerAsset } from 'expo-image-picker';
 
 import {
+  ProductCloseResponse,
   ProductCreateRequest,
   ProductCreateResponse,
   ProductDeleteResponse,
@@ -190,6 +191,16 @@ export async function updateProductApi(
   }
 
   return data as ProductUpdateResponse;
+}
+
+export async function closeProductApi(
+  productId: number,
+  accessToken: string
+): Promise<ProductCloseResponse> {
+  return apiFetch<ProductCloseResponse>(`/api/products/${productId}/close`, {
+    method: 'POST',
+    accessToken,
+  });
 }
 
 export async function deleteProductApi(

--- a/api/types.ts
+++ b/api/types.ts
@@ -168,6 +168,8 @@ export type ProductUpdateResponse = ProductDetailResponse;
 
 export type ProductDeleteResponse = ApiResponse<{ product_id: number }>;
 
+export type ProductCloseResponse = ApiResponse<void>;
+
 // ── Bid ──
 
 export type BidCreateRequest = {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,8 +5,8 @@ import { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
-import { useAuthActions, useIsInitialized, useIsLoggedIn } from '../store/useAuthStore';
-import { COLORS } from '../constants/theme';
+import { useAuthActions, useIsInitialized, useIsLoggedIn } from '@/store/useAuthStore';
+import { COLORS } from '@/constants/theme';
 
 // ──────────────────────────────────────────────────────────────────
 // 라우트 가드 컴포넌트

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -12,11 +12,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useState, useRef, useEffect } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useChatMessagesQuery } from '../../hooks/chat/useChatMessagesQuery';
-import { useSendMessageMutation } from '../../hooks/chat/useSendMessageMutation';
-import { useChatListQuery } from '../../hooks/chat/useChatListQuery';
-import { COLORS, ICON_SIZES } from '../../constants/theme';
-import useAuthStore from '../../store/useAuthStore';
+import { useChatMessagesQuery } from '@/hooks/chat/useChatMessagesQuery';
+import { useSendMessageMutation } from '@/hooks/chat/useSendMessageMutation';
+import { useChatListQuery } from '@/hooks/chat/useChatListQuery';
+import { COLORS, ICON_SIZES } from '@/constants/theme';
+import useAuthStore from '@/store/useAuthStore';
 
 function formatMessageTime(createdAt: string): string {
   const date = new Date(createdAt);

--- a/app/chat/index.tsx
+++ b/app/chat/index.tsx
@@ -1,10 +1,10 @@
 import { View, Text, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import TabBar from '../../components/layout/TabBar';
+import TabBar from '@/components/layout/TabBar';
 import { useRouter } from 'expo-router';
-import { useChatListQuery } from '../../hooks/chat/useChatListQuery';
-import { COLORS } from '../../constants/theme';
+import { useChatListQuery } from '@/hooks/chat/useChatListQuery';
+import { COLORS } from '@/constants/theme';
 
 function formatChatDate(updatedAt: string): string {
   const date = new Date(updatedAt);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,12 +1,12 @@
 import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useState } from 'react';
-import TopBar from '../components/layout/TopBar';
-import SearchBar from '../components/layout/SearchBar';
-import CategoryBar from '../components/layout/CategoryBar';
-import ProductList from '../components/product/ProductList';
-import TabBar from '../components/layout/TabBar';
-import { ProductViewType } from '../api/types';
+import TopBar from '@/components/layout/TopBar';
+import SearchBar from '@/components/layout/SearchBar';
+import CategoryBar from '@/components/layout/CategoryBar';
+import ProductList from '@/components/product/ProductList';
+import TabBar from '@/components/layout/TabBar';
+import { ProductViewType } from '@/api/types';
 
 export default function Home() {
   const [activeCategory, setActiveCategory] = useState<ProductViewType>('ALL');

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -11,8 +11,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { COLORS, INPUT_STYLE, LAYOUT } from '../constants/theme';
-import { useLoginMutation } from '../hooks/auth/useLoginMutation';
+import { COLORS, INPUT_STYLE, LAYOUT } from '@/constants/theme';
+import { useLoginMutation } from '@/hooks/auth/useLoginMutation';
 
 export default function LoginPage() {
   const router = useRouter();

--- a/app/mypage.tsx
+++ b/app/mypage.tsx
@@ -1,10 +1,10 @@
 import { View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
-import TabBar from '../components/layout/TabBar';
-import { COLORS } from '../constants/theme';
-import { MOCK_MILESTONES, MOCK_REWARDS, MOCK_FERTILITY } from '../mocks/mypage';
-import { useAuthActions } from '../store/useAuthStore';
+import TabBar from '@/components/layout/TabBar';
+import { COLORS } from '@/constants/theme';
+import { MOCK_MILESTONES, MOCK_REWARDS, MOCK_FERTILITY } from '@/mocks/mypage';
+import { useAuthActions } from '@/store/useAuthStore';
 
 export default function MyPage() {
   const { logout } = useAuthActions();

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -14,13 +14,14 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useState, useRef } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { useProductDetailQuery } from '../../hooks/product/useProductDetailQuery';
-import { useBidHistoryQuery } from '../../hooks/bid/useBidHistoryQuery';
-import { usePlaceBidMutation } from '../../hooks/bid/usePlaceBidMutation';
-import { COLORS, LAYOUT } from '../../constants/theme';
-import { formatPrice } from '../../utils/format';
-import useAuthStore from '../../store/useAuthStore';
-import { useToggleWishMutation } from '../../hooks/wish/useToggleWishMutation';
+import { useProductDetailQuery } from '@/hooks/product/useProductDetailQuery';
+import { useBidHistoryQuery } from '@/hooks/bid/useBidHistoryQuery';
+import { usePlaceBidMutation } from '@/hooks/bid/usePlaceBidMutation';
+import { COLORS, LAYOUT } from '@/constants/theme';
+import { formatPrice } from '@/utils/format';
+import useAuthStore from '@/store/useAuthStore';
+import { useToggleWishMutation } from '@/hooks/wish/useToggleWishMutation';
+import { useCloseProductMutation } from '@/hooks/product/useCloseProductMutation';
 
 function formatRemainingTime(endTimeStr: string): string {
   const end = new Date(endTimeStr);
@@ -74,6 +75,7 @@ export default function ProductDetail() {
   const { data: bidTrend } = useBidHistoryQuery(productId, { size: 10 });
   const { mutate: toggleWish } = useToggleWishMutation();
   const { mutate: placeBid, isPending: isBidding } = usePlaceBidMutation();
+  const { mutate: closeProduct, isPending: isClosing } = useCloseProductMutation();
 
   if (isLoading) {
     return (
@@ -125,21 +127,53 @@ export default function ProductDetail() {
       Alert.alert('입찰 실패', '현재가보다 높은 금액을 입력해주세요.');
       return;
     }
-    placeBid(
-      { productId, price },
+    Alert.alert('입찰 확인', '입찰 후에는 취소가 불가능합니다. 입찰하시겠습니까?', [
+      { text: '취소', style: 'cancel' },
       {
-        onSuccess: () => {
-          setBidModalVisible(false);
-          Alert.alert('입찰 완료', '입찰이 성공적으로 등록되었습니다.');
+        text: '입찰하기',
+        onPress: () => {
+          placeBid(
+            { productId, price },
+            {
+              onSuccess: () => {
+                setBidModalVisible(false);
+                Alert.alert('입찰 완료', '입찰이 성공적으로 등록되었습니다.');
+              },
+              onError: (error) => {
+                Alert.alert('입찰 실패', error.message);
+              },
+            }
+          );
         },
-        onError: (error) => {
-          Alert.alert('입찰 실패', error.message);
-        },
-      }
-    );
+      },
+    ]);
   };
 
+  const isAuctionActive = product.status === 'ON_SALE';
   const bidRecords = bidHistory?.content ?? [];
+
+  const handleAwardAuction = () => {
+    Alert.alert(
+      '낙찰 확인',
+      `최고가 입찰자(${bidRecords[0]?.bidder_name})에게 낙찰됩니다. 진행하시겠습니까?`,
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '낙찰하기',
+          onPress: () => {
+            closeProduct(productId, {
+              onSuccess: () => {
+                Alert.alert('낙찰 완료', '낙찰이 완료되었습니다.');
+              },
+              onError: (error) => {
+                Alert.alert('낙찰 실패', error.message);
+              },
+            });
+          },
+        },
+      ]
+    );
+  };
 
   // 가격 추이: 입찰 기록을 시간순(오래된 순)으로 정렬하여 바 차트 생성
   const trendBids = [...(bidTrend?.content ?? [])].reverse();
@@ -306,7 +340,7 @@ export default function ProductDetail() {
 
         {/* 가격 추이 */}
         <View className="bg-white px-4 py-4">
-          <Text className="mb-4 text-base font-bold text-gray-900">📈 가격 추이</Text>
+          <Text className="mb-4 text-base font-bold text-gray-900">가격 추이</Text>
           {trendBids.length === 0 ? (
             <Text className="py-4 text-center text-sm text-gray-400">
               아직 입찰 기록이 없습니다.
@@ -406,12 +440,28 @@ export default function ProductDetail() {
         </TouchableOpacity>
 
         {isOwner ? (
-          <TouchableOpacity
-            className="flex-1 items-center rounded-full py-4"
-            style={{ backgroundColor: COLORS.active }}
-            onPress={() => router.push(`/product/edit/${productId}`)}>
-            <Text className="text-base font-semibold text-white">수정하기</Text>
-          </TouchableOpacity>
+          <View className="flex-1 flex-row">
+            {isAuctionActive && bidRecords.length > 0 && (
+              <TouchableOpacity
+                className="mr-2 flex-1 items-center rounded-full py-4"
+                style={{
+                  backgroundColor: '#EF4444',
+                  opacity: isClosing ? 0.6 : 1,
+                }}
+                onPress={handleAwardAuction}
+                disabled={isClosing}>
+                <Text className="text-base font-semibold text-white">
+                  {isClosing ? '처리 중...' : '낙찰하기'}
+                </Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity
+              className="flex-1 items-center rounded-full py-4"
+              style={{ backgroundColor: COLORS.active }}
+              onPress={() => router.push(`/product/edit/${productId}`)}>
+              <Text className="text-base font-semibold text-white">수정하기</Text>
+            </TouchableOpacity>
+          </View>
         ) : (
           <TouchableOpacity
             className="flex-1 items-center rounded-full py-4"

--- a/app/product/edit/[id].tsx
+++ b/app/product/edit/[id].tsx
@@ -17,12 +17,12 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import TabBar from '../../../components/layout/TabBar';
-import { COLORS, INPUT_STYLE, LAYOUT } from '../../../constants/theme';
-import { useUpdateProductMutation } from '../../../hooks/product/useUpdateProductMutation';
-import { useDeleteProductMutation } from '../../../hooks/product/useDeleteProductMutation';
-import { useProductDetailQuery } from '../../../hooks/product/useProductDetailQuery';
-import { ProductMediaInfo } from '../../../api/types';
+import TabBar from '@/components/layout/TabBar';
+import { COLORS, INPUT_STYLE, LAYOUT } from '@/constants/theme';
+import { useUpdateProductMutation } from '@/hooks/product/useUpdateProductMutation';
+import { useDeleteProductMutation } from '@/hooks/product/useDeleteProductMutation';
+import { useProductDetailQuery } from '@/hooks/product/useProductDetailQuery';
+import { ProductMediaInfo } from '@/api/types';
 
 const MAX_DESCRIPTION_LENGTH = 2000;
 const MAX_IMAGE_COUNT = 10;
@@ -245,26 +245,45 @@ export default function ProductEdit() {
     );
   };
 
-  const handleDelete = () => {
-    Alert.alert('상품 삭제', '정말로 이 상품을 삭제하시겠습니까?', [
-      { text: '취소', style: 'cancel' },
-      {
-        text: '삭제',
-        style: 'destructive',
-        onPress: () => {
-          deleteProduct(productId, {
-            onSuccess: () => {
-              Alert.alert('삭제 완료', '상품이 삭제되었습니다.', [
-                { text: '확인', onPress: () => router.replace('/') },
-              ]);
-            },
-            onError: (error) => {
-              Alert.alert('삭제 실패', error.message);
-            },
-          });
-        },
+  const performDelete = () => {
+    deleteProduct(productId, {
+      onSuccess: () => {
+        Alert.alert('삭제 완료', '상품이 삭제되었습니다.', [
+          { text: '확인', onPress: () => router.replace('/') },
+        ]);
       },
-    ]);
+      onError: (error) => {
+        Alert.alert('삭제 실패', error.message);
+      },
+    });
+  };
+
+  const handleDelete = () => {
+    const hasBids = product && product.bid_count > 0;
+
+    if (hasBids) {
+      Alert.alert(
+        '상품 삭제',
+        `현재 ${product.bid_count}명의 입찰자가 있습니다. 정말로 삭제하시겠습니까?`,
+        [
+          { text: '취소', style: 'cancel' },
+          {
+            text: '삭제',
+            style: 'destructive',
+            onPress: performDelete,
+          },
+        ]
+      );
+    } else {
+      Alert.alert('상품 삭제', '정말로 이 상품을 삭제하시겠습니까?', [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '삭제',
+          style: 'destructive',
+          onPress: performDelete,
+        },
+      ]);
+    }
   };
 
   if (isLoading) {

--- a/app/productregister.tsx
+++ b/app/productregister.tsx
@@ -17,10 +17,10 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import * as ImagePicker from 'expo-image-picker';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { useRouter } from 'expo-router';
-import TabBar from '../components/layout/TabBar';
-import { COLORS, INPUT_STYLE, LAYOUT } from '../constants/theme';
-import { useCreateProductMutation } from '../hooks/product/useCreateProductMutation';
-import { useIsLoggedIn } from '../store/useAuthStore';
+import TabBar from '@/components/layout/TabBar';
+import { COLORS, INPUT_STYLE, LAYOUT } from '@/constants/theme';
+import { useCreateProductMutation } from '@/hooks/product/useCreateProductMutation';
+import { useIsLoggedIn } from '@/store/useAuthStore';
 
 const MAX_DESCRIPTION_LENGTH = 2000;
 const MAX_IMAGE_COUNT = 10;

--- a/app/register.tsx
+++ b/app/register.tsx
@@ -11,12 +11,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
-import { COLORS, INPUT_STYLE } from '../constants/theme';
-import EmailVerifyModal from '../components/modals/EmailVerifyModal';
-import { useCheckNicknameDuplicateMutation } from '../hooks/auth/useCheckNicknameDuplicateMutation';
-import { useSendEmailCodeMutation } from '../hooks/auth/useSendEmailCodeMutation';
-import { useSignupMutation } from '../hooks/auth/useSignupMutation';
-import { useVerifyEmailCodeMutation } from '../hooks/auth/useVerifyEmailCodeMutation';
+import { COLORS, INPUT_STYLE } from '@/constants/theme';
+import EmailVerifyModal from '@/components/modals/EmailVerifyModal';
+import { useCheckNicknameDuplicateMutation } from '@/hooks/auth/useCheckNicknameDuplicateMutation';
+import { useSendEmailCodeMutation } from '@/hooks/auth/useSendEmailCodeMutation';
+import { useSignupMutation } from '@/hooks/auth/useSignupMutation';
+import { useVerifyEmailCodeMutation } from '@/hooks/auth/useVerifyEmailCodeMutation';
 
 const EMAIL_VERIFY_EXPIRE_SECONDS = 10 * 60;
 

--- a/app/wishlist.tsx
+++ b/app/wishlist.tsx
@@ -2,12 +2,12 @@ import { View, Text, FlatList, TouchableOpacity, ActivityIndicator } from 'react
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import TabBar from '../components/layout/TabBar';
-import WishlistProduct from '../components/product/WishlistProduct';
-import { useWishlistQuery } from '../hooks/wish/useWishlistQuery';
-import { useToggleWishMutation } from '../hooks/wish/useToggleWishMutation';
-import { COLORS } from '../constants/theme';
-import type { WishSummary } from '../api/types';
+import TabBar from '@/components/layout/TabBar';
+import WishlistProduct from '@/components/product/WishlistProduct';
+import { useWishlistQuery } from '@/hooks/wish/useWishlistQuery';
+import { useToggleWishMutation } from '@/hooks/wish/useToggleWishMutation';
+import { COLORS } from '@/constants/theme';
+import type { WishSummary } from '@/api/types';
 
 export default function Wishlist() {
   const router = useRouter();

--- a/components/layout/CategoryBar.tsx
+++ b/components/layout/CategoryBar.tsx
@@ -1,6 +1,6 @@
 import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
-import { COLORS } from '../../constants/theme';
-import { ProductViewType } from '../../api/types';
+import { COLORS } from '@/constants/theme';
+import { ProductViewType } from '@/api/types';
 
 interface CategoryBarProps {
   activeCategory: ProductViewType;

--- a/components/layout/SearchBar.tsx
+++ b/components/layout/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { View, TextInput, TouchableOpacity } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { COLORS } from '../../constants/theme';
+import { COLORS } from '@/constants/theme';
 
 export default function SearchBar() {
   return (

--- a/components/layout/TabBar.tsx
+++ b/components/layout/TabBar.tsx
@@ -1,9 +1,9 @@
 import { Platform, View, Text, TouchableOpacity } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useTabNavigation } from '../../hooks/useTabNavigation';
-import type { TabId } from '../../types/tab';
-import { COLORS, ICON_SIZES, LAYOUT } from '../../constants/theme';
+import { useTabNavigation } from '@/hooks/useTabNavigation';
+import type { TabId } from '@/types/tab';
+import { COLORS, ICON_SIZES, LAYOUT } from '@/constants/theme';
 
 interface Tab {
   id: TabId;

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -1,6 +1,6 @@
 import { View, Text, TouchableOpacity } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { COLORS } from '../../constants/theme';
+import { COLORS } from '@/constants/theme';
 
 export default function TopBar() {
   return (

--- a/components/modals/EmailVerifyModal.tsx
+++ b/components/modals/EmailVerifyModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Modal, Pressable, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { COLORS, INPUT_STYLE, LAYOUT } from '../../constants/theme';
+import { COLORS, INPUT_STYLE, LAYOUT } from '@/constants/theme';
 
 // 백엔드 명세 기준 6자리 코드를 입력받습니다.
 const CODE_LENGTH = 6;

--- a/components/product/Product.tsx
+++ b/components/product/Product.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Image, TouchableOpacity, Platform } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { COLORS, SHADOWS } from '../../constants/theme';
-import { formatPrice } from '../../utils/format';
+import { COLORS, SHADOWS } from '@/constants/theme';
+import { formatPrice } from '@/utils/format';
 
 interface ProductProps {
   id: string;
@@ -137,12 +137,10 @@ export default function Product({
       </View>
 
       {/* 참여자 수 */}
-      {participants > 0 && (
-        <View className="mt-2 flex-row items-center pl-1">
-          <MaterialCommunityIcons name="account-outline" size={14} color={COLORS.textMuted} />
-          <Text className="ml-1 text-xs text-gray-500">{participants}명 참여중</Text>
-        </View>
-      )}
+      <View className="mt-2 flex-row items-center pl-1">
+        <MaterialCommunityIcons name="account-outline" size={14} color={COLORS.textMuted} />
+        <Text className="ml-1 text-xs text-gray-500">{participants}명 참여중</Text>
+      </View>
     </TouchableOpacity>
   );
 }

--- a/components/product/ProductList.tsx
+++ b/components/product/ProductList.tsx
@@ -2,11 +2,11 @@ import { View, Text, ActivityIndicator } from 'react-native';
 import { useMemo } from 'react';
 import { useRouter } from 'expo-router';
 import Product from './Product';
-import { useProductsQuery } from '../../hooks/product/useProductsQuery';
-import { useWishlistQuery } from '../../hooks/wish/useWishlistQuery';
-import { useToggleWishMutation } from '../../hooks/wish/useToggleWishMutation';
-import { COLORS } from '../../constants/theme';
-import { ProductViewType } from '../../api/types';
+import { useProductsQuery } from '@/hooks/product/useProductsQuery';
+import { useWishlistQuery } from '@/hooks/wish/useWishlistQuery';
+import { useToggleWishMutation } from '@/hooks/wish/useToggleWishMutation';
+import { COLORS } from '@/constants/theme';
+import { ProductViewType } from '@/api/types';
 
 interface ProductListProps {
   viewType?: ProductViewType;

--- a/components/product/WishlistProduct.tsx
+++ b/components/product/WishlistProduct.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Image, TouchableOpacity } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { COLORS, SHADOWS } from '../../constants/theme';
-import { formatPrice } from '../../utils/format';
+import { COLORS, SHADOWS } from '@/constants/theme';
+import { formatPrice } from '@/utils/format';
 
 interface WishlistProductProps {
   productId: number;

--- a/hooks/auth/useCheckNicknameDuplicateMutation.ts
+++ b/hooks/auth/useCheckNicknameDuplicateMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { checkNicknameDuplicateApi } from '../../api/auth';
+import { checkNicknameDuplicateApi } from '@/api/auth';
 
 export function useCheckNicknameDuplicateMutation() {
   return useMutation({

--- a/hooks/auth/useLoginMutation.ts
+++ b/hooks/auth/useLoginMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import { loginApi } from '../../api/auth';
-import { setRefreshToken, setStoredUserId } from '../../lib/secureStore';
-import { useAuthActions } from '../../store/useAuthStore';
+import { loginApi } from '@/api/auth';
+import { setRefreshToken, setStoredUserId } from '@/lib/secureStore';
+import { useAuthActions } from '@/store/useAuthStore';
 
 function readStringCandidate(source: Record<string, unknown>, keys: string[]) {
   for (const key of keys) {

--- a/hooks/auth/useLogoutMutation.ts
+++ b/hooks/auth/useLogoutMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useAuthActions } from '../../store/useAuthStore';
+import { useAuthActions } from '@/store/useAuthStore';
 
 export function useLogoutMutation() {
   const { logout } = useAuthActions();

--- a/hooks/auth/useSendEmailCodeMutation.ts
+++ b/hooks/auth/useSendEmailCodeMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { sendEmailCodeApi } from '../../api/auth';
+import { sendEmailCodeApi } from '@/api/auth';
 
 export function useSendEmailCodeMutation() {
   return useMutation({

--- a/hooks/auth/useSignupMutation.ts
+++ b/hooks/auth/useSignupMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { signupApi } from '../../api/auth';
+import { signupApi } from '@/api/auth';
 
 export function useSignupMutation() {
   return useMutation({

--- a/hooks/auth/useVerifyEmailCodeMutation.ts
+++ b/hooks/auth/useVerifyEmailCodeMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { verifyEmailCodeApi } from '../../api/auth';
+import { verifyEmailCodeApi } from '@/api/auth';
 
 export function useVerifyEmailCodeMutation() {
   return useMutation({

--- a/hooks/bid/useBidHistoryQuery.ts
+++ b/hooks/bid/useBidHistoryQuery.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getBidHistoryApi } from '../../api/bid';
-import { BidListParams } from '../../api/types';
-import useAuthStore, { useIsLoggedIn } from '../../store/useAuthStore';
+import { getBidHistoryApi } from '@/api/bid';
+import { BidListParams } from '@/api/types';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useBidHistoryQuery(productId: number, params: BidListParams = {}) {
   const isLoggedIn = useIsLoggedIn();

--- a/hooks/bid/usePlaceBidMutation.ts
+++ b/hooks/bid/usePlaceBidMutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { placeBidApi } from '../../api/bid';
-import { BidCreateResponse, ProductDetailResponse } from '../../api/types';
-import { useAccessToken } from '../../store/useAuthStore';
+import { placeBidApi } from '@/api/bid';
+import { BidCreateResponse, ProductDetailResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
 
 type PlaceBidParams = {
   productId: number;

--- a/hooks/chat/useChatListQuery.ts
+++ b/hooks/chat/useChatListQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getChatListApi } from '../../api/chat';
-import useAuthStore, { useIsLoggedIn } from '../../store/useAuthStore';
+import { getChatListApi } from '@/api/chat';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useChatListQuery() {
   const isLoggedIn = useIsLoggedIn();

--- a/hooks/chat/useChatMessagesQuery.ts
+++ b/hooks/chat/useChatMessagesQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getChatMessagesApi } from '../../api/chat';
-import useAuthStore, { useIsLoggedIn } from '../../store/useAuthStore';
+import { getChatMessagesApi } from '@/api/chat';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useChatMessagesQuery(chatId: number) {
   const isLoggedIn = useIsLoggedIn();

--- a/hooks/chat/useSendMessageMutation.ts
+++ b/hooks/chat/useSendMessageMutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { sendMessageApi } from '../../api/chat';
-import { ChatMessageSendResponse } from '../../api/types';
-import { useAccessToken } from '../../store/useAuthStore';
+import { sendMessageApi } from '@/api/chat';
+import { ChatMessageSendResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
 
 type SendMessageParams = {
   chatId: number;

--- a/hooks/product/useCloseProductMutation.ts
+++ b/hooks/product/useCloseProductMutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { deleteProductApi } from '@/api/product';
+import { closeProductApi } from '@/api/product';
 import { useAccessToken } from '@/store/useAuthStore';
 
-export function useDeleteProductMutation() {
+export function useCloseProductMutation() {
   const accessToken = useAccessToken();
   const queryClient = useQueryClient();
 
@@ -12,10 +12,12 @@ export function useDeleteProductMutation() {
       if (!accessToken) {
         throw new Error('로그인이 필요합니다.');
       }
-      return deleteProductApi(productId, accessToken);
+      return closeProductApi(productId, accessToken);
     },
-    onSuccess: () => {
+    onSuccess: (_data, productId) => {
+      queryClient.invalidateQueries({ queryKey: ['product', productId] });
       queryClient.invalidateQueries({ queryKey: ['products'] });
+      queryClient.invalidateQueries({ queryKey: ['bidHistory', productId] });
     },
   });
 }

--- a/hooks/product/useCreateProductMutation.ts
+++ b/hooks/product/useCreateProductMutation.ts
@@ -1,9 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { ImagePickerAsset } from 'expo-image-picker';
 
-import { createProductApi } from '../../api/product';
-import { ProductCreateRequest } from '../../api/types';
-import { useAccessToken } from '../../store/useAuthStore';
+import { createProductApi } from '@/api/product';
+import { ProductCreateRequest } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
 
 type CreateProductParams = {
   request: ProductCreateRequest;

--- a/hooks/product/useProductDetailQuery.ts
+++ b/hooks/product/useProductDetailQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getProductDetailApi } from '../../api/product';
-import useAuthStore, { useIsLoggedIn } from '../../store/useAuthStore';
+import { getProductDetailApi } from '@/api/product';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useProductDetailQuery(productId: number) {
   const isLoggedIn = useIsLoggedIn();

--- a/hooks/product/useProductsQuery.ts
+++ b/hooks/product/useProductsQuery.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getProductsApi } from '../../api/product';
-import { ProductListParams } from '../../api/types';
-import useAuthStore, { useIsLoggedIn } from '../../store/useAuthStore';
+import { getProductsApi } from '@/api/product';
+import { ProductListParams } from '@/api/types';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useProductsQuery(params: ProductListParams = {}) {
   const isLoggedIn = useIsLoggedIn();

--- a/hooks/product/useUpdateProductMutation.ts
+++ b/hooks/product/useUpdateProductMutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ImagePickerAsset } from 'expo-image-picker';
 
-import { updateProductApi } from '../../api/product';
-import { ProductUpdateRequest } from '../../api/types';
-import { useAccessToken } from '../../store/useAuthStore';
+import { updateProductApi } from '@/api/product';
+import { ProductUpdateRequest } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
 
 type UpdateProductParams = {
   productId: number;

--- a/hooks/useTabNavigation.ts
+++ b/hooks/useTabNavigation.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect } from 'react';
 import { useRouter, usePathname } from 'expo-router';
 import { useActiveTab, useTabActions } from '@/store/useTabStore';
-import type { TabId } from '../types/tab';
+import type { TabId } from '@/types/tab';
 
 // 경로 → 탭 ID 매핑
 const ROUTE_TO_TAB: Record<string, TabId> = {

--- a/hooks/wish/useToggleWishMutation.ts
+++ b/hooks/wish/useToggleWishMutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { addWishApi, removeWishApi } from '../../api/wish';
-import { ProductDetailResponse } from '../../api/types';
-import { useAccessToken } from '../../store/useAuthStore';
+import { addWishApi, removeWishApi } from '@/api/wish';
+import { ProductDetailResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
 
 type ToggleWishParams = {
   productId: number;

--- a/hooks/wish/useWishlistQuery.ts
+++ b/hooks/wish/useWishlistQuery.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getWishlistApi } from '../../api/wish';
-import { WishListParams } from '../../api/types';
-import { useAccessToken, useIsLoggedIn } from '../../store/useAuthStore';
+import { getWishlistApi } from '@/api/wish';
+import { WishListParams } from '@/api/types';
+import { useAccessToken, useIsLoggedIn } from '@/store/useAuthStore';
 
 export function useWishlistQuery(params: WishListParams = {}) {
   const accessToken = useAccessToken();

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -1,14 +1,14 @@
 import { create } from 'zustand';
 import { combine, devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { logoutApi, refreshApi } from '../api/auth';
+import { logoutApi, refreshApi } from '@/api/auth';
 import {
   getRefreshToken,
   getStoredUserId,
   removeRefreshToken,
   removeStoredUserId,
   setRefreshToken,
-} from '../lib/secureStore';
+} from '@/lib/secureStore';
 
 type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
 

--- a/store/useTabStore.ts
+++ b/store/useTabStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { devtools, combine } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import type { TabId } from '../types/tab';
+import type { TabId } from '@/types/tab';
 
 const initialState = {
   activeTab: 'home' as TabId,


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 경매 수동 마감 및 낙찰 API 연동, 입찰 확인 Alert 추가 및 import 경로 정리를 진행하였습니다.

## 📝 변경 사항 요약 (Summary)

- 경매 마감 API(POST /api/products/{productId}/close) 연동
- 입찰자 유무에 따라 낙찰하기/마감하기 버튼 분기 표시
- 입찰 시 취소 불가 확인 Alert 추가
- 상품 삭제 시 입찰자 존재 여부에 따른 경고 Alert 추가
- 0명 참여중 표시 활성화
- 프로젝트 전반 상대 경로 import를 @/ alias로 통일

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #53 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)