### PR TITLE
#58 feat(mypage): 마이페이지 API 연동 및 mock 데이터 제거

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -18,7 +18,9 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
   // 중복 슬래시로 잘못된 URL이 만들어지지 않도록 정규화합니다.
   const normalizedBaseUrl = BASE_URL.replace(/\/+$/, '');
 
-  headers.set('Content-Type', 'application/json');
+  if (options.body) {
+    headers.set('Content-Type', 'application/json');
+  }
   headers.set('Accept', 'application/json');
 
   if (options.accessToken) {

--- a/api/types.ts
+++ b/api/types.ts
@@ -59,6 +59,27 @@ export type VerifyEmailCodeResponse = ApiResponse<{
 
 export type LogoutResponse = ApiResponse<string>;
 
+// ── User ──
+
+export type UserProfile = {
+  user_id: number;
+  email: string;
+  name: string;
+  address: string;
+  profile_image_url: string | null;
+};
+
+export type UserProfileResponse = ApiResponse<UserProfile>;
+
+export type UpdateUserProfileRequest = {
+  name?: string;
+  address?: string;
+};
+
+export type UpdateUserProfileResponse = ApiResponse<UserProfile>;
+
+export type DeleteUserResponse = ApiResponse<null>;
+
 // ── Product ──
 
 export type ProductCreateRequest = {

--- a/api/user.ts
+++ b/api/user.ts
@@ -1,0 +1,27 @@
+import { apiFetch } from './client';
+import type {
+  DeleteUserResponse,
+  UpdateUserProfileRequest,
+  UpdateUserProfileResponse,
+  UserProfileResponse,
+} from './types';
+
+export function getUserProfileApi(accessToken: string) {
+  return apiFetch<UserProfileResponse>('/api/users/me', { accessToken });
+}
+
+export function updateUserProfileApi(body: UpdateUserProfileRequest, accessToken: string) {
+  return apiFetch<UpdateUserProfileResponse>('/api/users/me', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+    accessToken,
+  });
+}
+
+export function deleteUserApi(accessToken: string, refreshToken: string) {
+  return apiFetch<DeleteUserResponse>('/api/users/me', {
+    method: 'DELETE',
+    headers: { 'Refresh-Token': refreshToken },
+    accessToken,
+  });
+}

--- a/app/mypage/change-address.tsx
+++ b/app/mypage/change-address.tsx
@@ -1,20 +1,32 @@
 import { useState } from 'react';
-import { View, Text, TextInput, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { COLORS } from '@/constants/theme';
+import { useUpdateUserProfileMutation } from '@/hooks/user/useUpdateUserProfileMutation';
 
 export default function ChangeAddress() {
   const router = useRouter();
   const [address, setAddress] = useState('');
+  const updateProfileMutation = useUpdateUserProfileMutation();
 
   const canSubmit = address.trim().length > 0;
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    // TODO: 주소 변경 API 연동
-    router.back();
+    updateProfileMutation.mutate(
+      { address: address.trim() },
+      {
+        onSuccess: () => {
+          Alert.alert('완료', '주소가 변경되었습니다.');
+          router.back();
+        },
+        onError: (error) => {
+          Alert.alert('실패', error.message);
+        },
+      }
+    );
   };
 
   return (
@@ -53,9 +65,11 @@ export default function ChangeAddress() {
         <TouchableOpacity
           className="items-center rounded-xl py-4"
           style={{ backgroundColor: COLORS.primary, opacity: canSubmit ? 1 : 0.5 }}
-          disabled={!canSubmit}
+          disabled={!canSubmit || updateProfileMutation.isPending}
           onPress={handleSubmit}>
-          <Text className="text-base font-bold text-white">주소 변경하기</Text>
+          <Text className="text-base font-bold text-white">
+            {updateProfileMutation.isPending ? '변경 중...' : '주소 변경하기'}
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>

--- a/app/mypage/change-nickname.tsx
+++ b/app/mypage/change-nickname.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { View, Text, TextInput, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { COLORS, INPUT_STYLE } from '@/constants/theme';
 import { useCheckNicknameDuplicateMutation } from '@/hooks/auth/useCheckNicknameDuplicateMutation';
+import { useUpdateUserProfileMutation } from '@/hooks/user/useUpdateUserProfileMutation';
 
 export default function ChangeNickname() {
   const router = useRouter();
@@ -13,6 +14,7 @@ export default function ChangeNickname() {
   const [checkedNickname, setCheckedNickname] = useState('');
 
   const checkNicknameMutation = useCheckNicknameDuplicateMutation();
+  const updateProfileMutation = useUpdateUserProfileMutation();
 
   const handleCheckNickname = () => {
     const trimmed = nickname.trim();
@@ -33,8 +35,18 @@ export default function ChangeNickname() {
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    // TODO: 닉네임 변경 API 연동
-    router.back();
+    updateProfileMutation.mutate(
+      { name: checkedNickname },
+      {
+        onSuccess: () => {
+          Alert.alert('완료', '닉네임이 변경되었습니다.');
+          router.back();
+        },
+        onError: (error) => {
+          Alert.alert('실패', error.message);
+        },
+      }
+    );
   };
 
   return (
@@ -100,9 +112,11 @@ export default function ChangeNickname() {
         <TouchableOpacity
           className="items-center rounded-xl py-4"
           style={{ backgroundColor: COLORS.primary, opacity: canSubmit ? 1 : 0.5 }}
-          disabled={!canSubmit}
+          disabled={!canSubmit || updateProfileMutation.isPending}
           onPress={handleSubmit}>
-          <Text className="text-base font-bold text-white">닉네임 변경하기</Text>
+          <Text className="text-base font-bold text-white">
+            {updateProfileMutation.isPending ? '변경 중...' : '닉네임 변경하기'}
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>

--- a/app/mypage/edit-profile.tsx
+++ b/app/mypage/edit-profile.tsx
@@ -1,17 +1,10 @@
-import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { COLORS } from '@/constants/theme';
 import TabBar from '@/components/layout/TabBar';
-
-// Mock 데이터
-const PROFILE = {
-  email: '11111111@edu.hanbat.ac.kr',
-  nickname: '학생 1',
-  address: '010-****-1111',
-  password: '••••••••••',
-};
+import { useUserProfileQuery } from '@/hooks/user/useUserProfileQuery';
 
 type ProfileField = {
   label: string;
@@ -19,15 +12,16 @@ type ProfileField = {
   editable?: boolean;
 };
 
-const FIELDS: ProfileField[] = [
-  { label: '이메일', value: PROFILE.email },
-  { label: '닉네임', value: PROFILE.nickname, editable: true },
-  { label: '주소', value: PROFILE.address, editable: true },
-  { label: '비밀번호', value: PROFILE.password, editable: true },
-];
-
 export default function EditProfile() {
   const router = useRouter();
+  const { data: profile, isLoading } = useUserProfileQuery();
+
+  const fields: ProfileField[] = [
+    { label: '이메일', value: profile?.email ?? '' },
+    { label: '닉네임', value: profile?.name ?? '', editable: true },
+    { label: '주소', value: profile?.address ?? '', editable: true },
+    { label: '비밀번호', value: '••••••••••', editable: true },
+  ];
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={['top']}>
@@ -42,64 +36,78 @@ export default function EditProfile() {
         <View style={{ width: 28 }} />
       </View>
 
-      <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
-        {/* 프로필 이미지 */}
-        <View className="items-center pb-6 pt-4">
-          <View style={{ width: 96, height: 96 }}>
-            <View
-              className="h-24 w-24 items-center justify-center overflow-hidden rounded-full"
-              style={{ backgroundColor: COLORS.primary }}>
-              <MaterialCommunityIcons
-                name="account"
-                size={48}
-                color="white"
-                style={{ marginTop: -8 }}
-              />
-              <TouchableOpacity
-                className="absolute bottom-0 left-0 right-0 items-center py-1.5"
-                style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
-                <Text className="text-xs font-semibold text-white">편집</Text>
-              </TouchableOpacity>
-            </View>
-          </View>
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color={COLORS.primary} />
         </View>
-
-        {/* 프로필 정보 */}
-        <View className="px-5">
-          <Text className="mb-4 text-lg font-bold text-gray-900">프로필 정보</Text>
-
-          {FIELDS.map((field, index) => (
-            <View
-              key={field.label}
-              className={`pb-4 pt-3 ${index !== FIELDS.length - 1 ? 'border-b border-gray-100' : ''}`}>
-              <Text className="mb-1 text-sm font-semibold text-gray-900">{field.label}</Text>
-              <View className="flex-row items-center justify-between">
-                <Text
-                  className={`text-sm ${field.label === '이메일' ? 'rounded-lg bg-gray-100 px-3 py-2.5 text-gray-500' : 'py-1 text-gray-700'}`}
-                  style={field.label === '이메일' ? { flex: 1 } : undefined}>
-                  {field.value}
-                </Text>
-                {field.editable && (
-                  <TouchableOpacity
-                    className="rounded-lg border px-4 py-1.5"
-                    style={{ borderColor: COLORS.primary }}
-                    onPress={() => {
-                      if (field.label === '닉네임') router.push('/mypage/change-nickname');
-                      if (field.label === '주소') router.push('/mypage/change-address');
-                      if (field.label === '비밀번호') router.push('/mypage/change-password');
-                    }}>
-                    <Text className="text-sm font-medium" style={{ color: COLORS.primary }}>
-                      변경
-                    </Text>
-                  </TouchableOpacity>
+      ) : (
+        <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
+          {/* 프로필 이미지 */}
+          <View className="items-center pb-6 pt-4">
+            <View style={{ width: 96, height: 96 }}>
+              <View
+                className="h-24 w-24 items-center justify-center overflow-hidden rounded-full"
+                style={{ backgroundColor: COLORS.primary }}>
+                {profile?.profile_image_url ? (
+                  <Image
+                    source={{ uri: profile.profile_image_url }}
+                    className="h-full w-full"
+                    resizeMode="cover"
+                  />
+                ) : (
+                  <MaterialCommunityIcons
+                    name="account"
+                    size={48}
+                    color="white"
+                    style={{ marginTop: -8 }}
+                  />
                 )}
+                <TouchableOpacity
+                  className="absolute bottom-0 left-0 right-0 items-center py-1.5"
+                  style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
+                  <Text className="text-xs font-semibold text-white">편집</Text>
+                </TouchableOpacity>
               </View>
             </View>
-          ))}
-        </View>
+          </View>
 
-        <View className="h-8" />
-      </ScrollView>
+          {/* 프로필 정보 */}
+          <View className="px-5">
+            <Text className="mb-4 text-lg font-bold text-gray-900">프로필 정보</Text>
+
+            {fields.map((field, index) => (
+              <View
+                key={field.label}
+                className={`pb-4 pt-3 ${index !== fields.length - 1 ? 'border-b border-gray-100' : ''}`}>
+                <Text className="mb-1 text-sm font-semibold text-gray-900">{field.label}</Text>
+                <View className="flex-row items-center justify-between">
+                  <Text
+                    className={`text-sm ${field.label === '이메일' ? 'rounded-lg bg-gray-100 px-3 py-2.5 text-gray-500' : 'py-1 text-gray-700'}`}
+                    style={field.label === '이메일' ? { flex: 1 } : undefined}>
+                    {field.value}
+                  </Text>
+                  {field.editable && (
+                    <TouchableOpacity
+                      className="rounded-lg border px-4 py-1.5"
+                      style={{ borderColor: COLORS.primary }}
+                      onPress={() => {
+                        if (field.label === '닉네임') router.push('/mypage/change-nickname');
+                        if (field.label === '주소') router.push('/mypage/change-address');
+                        if (field.label === '비밀번호') router.push('/mypage/change-password');
+                      }}>
+                      <Text className="text-sm font-medium" style={{ color: COLORS.primary }}>
+                        변경
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              </View>
+            ))}
+          </View>
+
+          <View className="h-8" />
+        </ScrollView>
+      )}
 
       <TabBar />
     </SafeAreaView>

--- a/app/mypage/index.tsx
+++ b/app/mypage/index.tsx
@@ -1,27 +1,27 @@
-import { useState } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Alert, Modal } from 'react-native';
+import { useState, useMemo } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Alert, Modal, Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import TabBar from '@/components/layout/TabBar';
 import { COLORS, SHADOWS } from '@/constants/theme';
 import { useAuthActions } from '@/store/useAuthStore';
+import { useProductsQuery } from '@/hooks/product/useProductsQuery';
+import { useUserProfileQuery } from '@/hooks/user/useUserProfileQuery';
+import { useDeleteUserMutation } from '@/hooks/user/useDeleteUserMutation';
+import type { ProductSummary } from '@/api/types';
 
-// 구매 내역 mock 데이터
-const PURCHASE_HISTORY = {
-  전체: 0,
-  '입찰 중': 2,
-  '진행 중': 1,
-  종료: 1,
-};
-
-// 판매 내역 mock 데이터
-const SALE_HISTORY = {
-  전체: 0,
-  '입찰 중': '-',
-  '진행 중': '-',
-  종료: '-',
-};
+function countByStatus(products: ProductSummary[]) {
+  let bidding = 0;
+  let inProgress = 0;
+  let completed = 0;
+  for (const p of products) {
+    if (p.status === 'ON_SALE') bidding++;
+    else if (p.status === 'ENDED' || p.status === 'FAILED' || p.status === 'CANCELED') completed++;
+    else inProgress++;
+  }
+  return { total: products.length, bidding, inProgress, completed };
+}
 
 const WITHDRAWAL_REASONS = [
   '사이트 방문을 잘 하지 않아요',
@@ -32,10 +32,19 @@ const WITHDRAWAL_REASONS = [
 
 export default function MyPage() {
   const { logout } = useAuthActions();
+  const { data: profile } = useUserProfileQuery();
   const router = useRouter();
   const [showWithdrawModal, setShowWithdrawModal] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [selectedReason, setSelectedReason] = useState<string | null>(null);
+
+  const deleteUserMutation = useDeleteUserMutation();
+
+  const { data: bidsData } = useProductsQuery({ view: 'MY_BIDS' });
+  const { data: productsData } = useProductsQuery({ view: 'MY_PRODUCTS' });
+
+  const purchaseCounts = useMemo(() => countByStatus(bidsData?.content ?? []), [bidsData]);
+  const saleCounts = useMemo(() => countByStatus(productsData?.content ?? []), [productsData]);
 
   const handleLogout = () => {
     Alert.alert('로그아웃', '정말 로그아웃 하시겠습니까?', [
@@ -55,9 +64,16 @@ export default function MyPage() {
   };
 
   const handleConfirmWithdraw = () => {
-    setShowConfirmModal(false);
-    // TODO: 회원탈퇴 API 연동
-    logout();
+    deleteUserMutation.mutate(undefined, {
+      onSuccess: () => {
+        setShowConfirmModal(false);
+        logout();
+      },
+      onError: (error) => {
+        setShowConfirmModal(false);
+        Alert.alert('탈퇴 실패', error.message);
+      },
+    });
   };
 
   return (
@@ -77,11 +93,19 @@ export default function MyPage() {
         {/* 프로필 섹션 */}
         <View className="items-center pb-6 pt-4">
           <View
-            className="mb-3 h-24 w-24 items-center justify-center rounded-full"
+            className="mb-3 h-24 w-24 items-center justify-center overflow-hidden rounded-full"
             style={{ backgroundColor: COLORS.primary }}>
-            <MaterialCommunityIcons name="account" size={48} color="white" />
+            {profile?.profile_image_url ? (
+              <Image
+                source={{ uri: profile.profile_image_url }}
+                className="h-full w-full"
+                resizeMode="cover"
+              />
+            ) : (
+              <MaterialCommunityIcons name="account" size={48} color="white" />
+            )}
           </View>
-          <Text className="mb-2 text-xl font-bold text-gray-900">학생 1</Text>
+          <Text className="mb-2 text-xl font-bold text-gray-900">{profile?.name ?? '사용자'}</Text>
           <TouchableOpacity
             className="rounded-full border px-4 py-1.5"
             style={{ borderColor: COLORS.primary }}
@@ -98,7 +122,12 @@ export default function MyPage() {
           <TouchableOpacity
             className="mb-5 flex-row rounded-xl border border-gray-200 bg-white py-3"
             onPress={() => router.push('/mypage/purchase-history')}>
-            {Object.entries(PURCHASE_HISTORY).map(([label, count]) => (
+            {[
+              { label: '전체', count: purchaseCounts.total },
+              { label: '입찰 중', count: purchaseCounts.bidding },
+              { label: '진행 중', count: purchaseCounts.inProgress },
+              { label: '종료', count: purchaseCounts.completed },
+            ].map(({ label, count }) => (
               <View key={label} className="flex-1 items-center">
                 <Text className="mb-1 text-sm text-gray-500">{label}</Text>
                 <Text
@@ -114,7 +143,12 @@ export default function MyPage() {
           <TouchableOpacity
             className="flex-row rounded-xl border border-gray-200 bg-white py-3"
             onPress={() => router.push('/mypage/sale-history')}>
-            {Object.entries(SALE_HISTORY).map(([label, count]) => (
+            {[
+              { label: '전체', count: saleCounts.total },
+              { label: '입찰 중', count: saleCounts.bidding },
+              { label: '진행 중', count: saleCounts.inProgress },
+              { label: '종료', count: saleCounts.completed },
+            ].map(({ label, count }) => (
               <View key={label} className="flex-1 items-center">
                 <Text className="mb-1 text-sm text-gray-500">{label}</Text>
                 <Text

--- a/app/mypage/purchase-history.tsx
+++ b/app/mypage/purchase-history.tsx
@@ -1,85 +1,45 @@
-import { View, Text, ScrollView, TouchableOpacity, Image, Platform } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { COLORS, SHADOWS } from '@/constants/theme';
 import { formatPrice } from '@/utils/format';
+import { useProductsQuery } from '@/hooks/product/useProductsQuery';
+import type { ProductSummary } from '@/api/types';
 
 type TabId = 'bidding' | 'inProgress' | 'completed';
 
-const TABS: { id: TabId; label: string; count: number }[] = [
-  { id: 'bidding', label: '구매 입찰', count: 2 },
-  { id: 'inProgress', label: '진행 중', count: 1 },
-  { id: 'completed', label: '종료', count: 1 },
-];
+const TAB_LABELS: Record<TabId, string> = {
+  bidding: '구매 입찰',
+  inProgress: '진행 중',
+  completed: '종료',
+};
 
 const SUB_HEADERS: Record<TabId, string[]> = {
-  bidding: ['구매 희망가', '만료일'],
+  bidding: ['현재가', '만료일'],
   inProgress: ['거래 예정일'],
   completed: ['거래일'],
 };
 
-type PurchaseItem = {
-  id: number;
-  seller: string;
-  name: string;
-  originalPrice: number;
-  currentPrice: number;
-  date: string;
-  image: string | null;
-  endTime?: string;
-  participants?: number;
-};
-
-const MOCK_DATA: Record<TabId, PurchaseItem[]> = {
-  bidding: [
-    {
-      id: 1,
-      seller: '학생2',
-      name: '콜라 5개',
-      originalPrice: 5000,
-      currentPrice: 5000,
-      date: '26/01/01',
-      image: null,
-      endTime: '2026-01-01T23:59:59',
-      participants: 12,
-    },
-    {
-      id: 2,
-      seller: '학생1',
-      name: '고추참치',
-      originalPrice: 4000,
-      currentPrice: 4000,
-      date: '26/01/01',
-      image: null,
-      endTime: '2026-01-01T23:59:59',
-      participants: 10,
-    },
-  ],
-  inProgress: [
-    {
-      id: 3,
-      seller: '학생a',
-      name: '후드티',
-      originalPrice: 25000,
-      currentPrice: 25000,
-      date: '26/01/02',
-      image: null,
-    },
-  ],
-  completed: [
-    {
-      id: 4,
-      seller: '학생2',
-      name: '모자',
-      originalPrice: 10000,
-      currentPrice: 10000,
-      date: '25/12/24',
-      image: null,
-    },
-  ],
-};
+function filterByTab(products: ProductSummary[], tab: TabId): ProductSummary[] {
+  switch (tab) {
+    case 'bidding':
+      return products.filter((p) => p.status === 'ON_SALE');
+    case 'completed':
+      return products.filter(
+        (p) => p.status === 'ENDED' || p.status === 'FAILED' || p.status === 'CANCELED'
+      );
+    case 'inProgress':
+      return products.filter(
+        (p) =>
+          p.status !== 'ON_SALE' &&
+          p.status !== 'ENDED' &&
+          p.status !== 'FAILED' &&
+          p.status !== 'CANCELED'
+      );
+  }
+}
 
 function formatRemainingTime(endTimeStr: string): string {
   const end = new Date(endTimeStr);
@@ -98,7 +58,19 @@ export default function PurchaseHistory() {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabId>('bidding');
 
-  const items = MOCK_DATA[activeTab];
+  const { data, isLoading } = useProductsQuery({ view: 'MY_BIDS' });
+  const products = data?.content ?? [];
+
+  const grouped = useMemo(
+    () => ({
+      bidding: filterByTab(products, 'bidding'),
+      inProgress: filterByTab(products, 'inProgress'),
+      completed: filterByTab(products, 'completed'),
+    }),
+    [products]
+  );
+
+  const items = grouped[activeTab];
   const subHeaders = SUB_HEADERS[activeTab];
 
   return (
@@ -116,23 +88,23 @@ export default function PurchaseHistory() {
 
       {/* 탭 */}
       <View className="flex-row border-b border-gray-100">
-        {TABS.map((tab) => {
-          const isActive = activeTab === tab.id;
+        {(['bidding', 'inProgress', 'completed'] as TabId[]).map((tabId) => {
+          const isActive = activeTab === tabId;
           return (
             <TouchableOpacity
-              key={tab.id}
-              onPress={() => setActiveTab(tab.id)}
+              key={tabId}
+              onPress={() => setActiveTab(tabId)}
               className="flex-1 items-center pb-3 pt-2"
               style={isActive ? { borderBottomWidth: 2, borderBottomColor: COLORS.primary } : {}}>
               <Text
                 className="text-lg font-bold"
                 style={{ color: isActive ? COLORS.primary : COLORS.textMuted }}>
-                {tab.count}
+                {grouped[tabId].length}
               </Text>
               <Text
                 className="text-sm font-medium"
                 style={{ color: isActive ? COLORS.primary : COLORS.textMuted }}>
-                {tab.label}
+                {TAB_LABELS[tabId]}
               </Text>
             </TouchableOpacity>
           );
@@ -149,36 +121,45 @@ export default function PurchaseHistory() {
       </View>
 
       {/* 리스트 */}
-      <ScrollView className="flex-1 px-4" showsVerticalScrollIndicator={false}>
-        {items.map((item) => (
-          <View key={item.id} className="mb-4 rounded-2xl bg-white p-3" style={SHADOWS.card}>
-            <View className="flex-row">
-              {/* 상품 이미지 */}
-              <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
-                {item.image ? (
-                  <Image
-                    source={{ uri: item.image }}
-                    className="h-full w-full"
-                    resizeMode="cover"
-                  />
-                ) : (
-                  <View className="h-full w-full items-center justify-center bg-gray-200">
-                    <MaterialCommunityIcons name="image-outline" size={32} color="#9CA3AF" />
-                  </View>
-                )}
-              </View>
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color={COLORS.primary} />
+        </View>
+      ) : (
+        <ScrollView className="flex-1 px-4" showsVerticalScrollIndicator={false}>
+          {items.map((item) => (
+            <TouchableOpacity
+              key={item.product_id}
+              className="mb-4 rounded-2xl bg-white p-3"
+              style={SHADOWS.card}
+              activeOpacity={0.7}
+              onPress={() => router.push(`/product/${item.product_id}`)}>
+              <View className="flex-row">
+                {/* 상품 이미지 */}
+                <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
+                  {item.media_url ? (
+                    <Image
+                      source={{ uri: item.media_url }}
+                      className="h-full w-full"
+                      resizeMode="cover"
+                    />
+                  ) : (
+                    <View className="h-full w-full items-center justify-center bg-gray-200">
+                      <MaterialCommunityIcons name="image-outline" size={32} color="#9CA3AF" />
+                    </View>
+                  )}
+                </View>
 
-              {/* 상품 정보 */}
-              <View className="flex-1">
-                <Text
-                  className="mb-1 text-base font-bold text-gray-900"
-                  numberOfLines={1}
-                  ellipsizeMode="tail">
-                  {item.name}
-                </Text>
+                {/* 상품 정보 */}
+                <View className="flex-1">
+                  <Text
+                    className="mb-1 text-base font-bold text-gray-900"
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
+                    {item.title}
+                  </Text>
 
-                {/* 남은 시간 또는 날짜 */}
-                {item.endTime ? (
+                  {/* 남은 시간 */}
                   <View className="mb-3 flex-row items-center">
                     <MaterialCommunityIcons
                       name="clock-outline"
@@ -186,56 +167,45 @@ export default function PurchaseHistory() {
                       color={COLORS.textMuted}
                     />
                     <Text className="ml-1 text-xs text-gray-500">
-                      {formatRemainingTime(item.endTime)}
-                    </Text>
-                  </View>
-                ) : (
-                  <View className="mb-3 flex-row items-center">
-                    <Text className="text-xs text-gray-500">{item.date}</Text>
-                  </View>
-                )}
-
-                {/* 가격 정보 */}
-                <View className="flex-row items-center">
-                  {/* 시작가 */}
-                  <View className="mr-2 flex-1 items-center rounded-lg bg-gray-100 px-2.5 py-1.5">
-                    <Text className="text-xs text-gray-500">시작가</Text>
-                    <Text className="text-xs font-bold text-gray-700">
-                      {formatPrice(item.originalPrice)}원
+                      {formatRemainingTime(item.end_time)}
                     </Text>
                   </View>
 
-                  {/* 현재가 */}
+                  {/* 가격 정보 */}
                   <View
-                    className="flex-1 items-center rounded-lg px-2.5 py-1.5"
+                    className="items-center self-start rounded-lg px-4 py-1.5"
                     style={{ backgroundColor: COLORS.primary }}>
                     <Text className="text-xs text-white">현재가</Text>
                     <Text className="text-xs font-bold text-white">
-                      {formatPrice(item.currentPrice)}원
+                      {formatPrice(item.current_price)}원
                     </Text>
                   </View>
                 </View>
               </View>
+
+              {/* 참여자 수 */}
+              {item.bid_count > 0 && (
+                <View className="mt-2 flex-row items-center pl-1">
+                  <MaterialCommunityIcons
+                    name="account-outline"
+                    size={14}
+                    color={COLORS.textMuted}
+                  />
+                  <Text className="ml-1 text-xs text-gray-500">{item.bid_count}명 참여중</Text>
+                </View>
+              )}
+            </TouchableOpacity>
+          ))}
+
+          {items.length === 0 && (
+            <View className="flex-1 items-center justify-center pt-20">
+              <Text className="text-gray-400">내역이 없습니다</Text>
             </View>
+          )}
 
-            {/* 참여자 수 */}
-            {item.participants != null && (
-              <View className="mt-2 flex-row items-center pl-1">
-                <MaterialCommunityIcons name="account-outline" size={14} color={COLORS.textMuted} />
-                <Text className="ml-1 text-xs text-gray-500">{item.participants}명 참여중</Text>
-              </View>
-            )}
-          </View>
-        ))}
-
-        {items.length === 0 && (
-          <View className="flex-1 items-center justify-center pt-20">
-            <Text className="text-gray-400">내역이 없습니다</Text>
-          </View>
-        )}
-
-        <View className="h-8" />
-      </ScrollView>
+          <View className="h-8" />
+        </ScrollView>
+      )}
     </SafeAreaView>
   );
 }

--- a/app/mypage/sale-history.tsx
+++ b/app/mypage/sale-history.tsx
@@ -1,74 +1,45 @@
-import { View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { COLORS, SHADOWS } from '@/constants/theme';
 import { formatPrice } from '@/utils/format';
+import { useProductsQuery } from '@/hooks/product/useProductsQuery';
+import type { ProductSummary } from '@/api/types';
 
 type TabId = 'bidding' | 'inProgress' | 'completed';
 
-const TABS: { id: TabId; label: string; count: number }[] = [
-  { id: 'bidding', label: '판매 입찰', count: 1 },
-  { id: 'inProgress', label: '진행 중', count: 1 },
-  { id: 'completed', label: '종료', count: 1 },
-];
+const TAB_LABELS: Record<TabId, string> = {
+  bidding: '판매 입찰',
+  inProgress: '진행 중',
+  completed: '종료',
+};
 
 const SUB_HEADERS: Record<TabId, string[]> = {
-  bidding: ['판매 희망가', '만료일'],
+  bidding: ['현재가', '만료일'],
   inProgress: ['거래 예정일'],
   completed: ['거래일'],
 };
 
-type SaleItem = {
-  id: number;
-  buyer: string;
-  name: string;
-  originalPrice: number;
-  currentPrice: number;
-  date: string;
-  image: string | null;
-  endTime?: string;
-  participants?: number;
-};
-
-const MOCK_DATA: Record<TabId, SaleItem[]> = {
-  bidding: [
-    {
-      id: 1,
-      buyer: '학생3',
-      name: '무선 키보드',
-      originalPrice: 15000,
-      currentPrice: 18000,
-      date: '26/01/15',
-      image: null,
-      endTime: '2026-01-15T23:59:59',
-      participants: 5,
-    },
-  ],
-  inProgress: [
-    {
-      id: 2,
-      buyer: '학생4',
-      name: '텀블러',
-      originalPrice: 8000,
-      currentPrice: 8000,
-      date: '26/01/10',
-      image: null,
-    },
-  ],
-  completed: [
-    {
-      id: 3,
-      buyer: '학생5',
-      name: '이어폰',
-      originalPrice: 12000,
-      currentPrice: 14000,
-      date: '25/12/20',
-      image: null,
-    },
-  ],
-};
+function filterByTab(products: ProductSummary[], tab: TabId): ProductSummary[] {
+  switch (tab) {
+    case 'bidding':
+      return products.filter((p) => p.status === 'ON_SALE');
+    case 'completed':
+      return products.filter(
+        (p) => p.status === 'ENDED' || p.status === 'FAILED' || p.status === 'CANCELED'
+      );
+    case 'inProgress':
+      return products.filter(
+        (p) =>
+          p.status !== 'ON_SALE' &&
+          p.status !== 'ENDED' &&
+          p.status !== 'FAILED' &&
+          p.status !== 'CANCELED'
+      );
+  }
+}
 
 function formatRemainingTime(endTimeStr: string): string {
   const end = new Date(endTimeStr);
@@ -87,7 +58,19 @@ export default function SaleHistory() {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState<TabId>('bidding');
 
-  const items = MOCK_DATA[activeTab];
+  const { data, isLoading } = useProductsQuery({ view: 'MY_PRODUCTS' });
+  const products = data?.content ?? [];
+
+  const grouped = useMemo(
+    () => ({
+      bidding: filterByTab(products, 'bidding'),
+      inProgress: filterByTab(products, 'inProgress'),
+      completed: filterByTab(products, 'completed'),
+    }),
+    [products]
+  );
+
+  const items = grouped[activeTab];
   const subHeaders = SUB_HEADERS[activeTab];
 
   return (
@@ -105,23 +88,23 @@ export default function SaleHistory() {
 
       {/* 탭 */}
       <View className="flex-row border-b border-gray-100">
-        {TABS.map((tab) => {
-          const isActive = activeTab === tab.id;
+        {(['bidding', 'inProgress', 'completed'] as TabId[]).map((tabId) => {
+          const isActive = activeTab === tabId;
           return (
             <TouchableOpacity
-              key={tab.id}
-              onPress={() => setActiveTab(tab.id)}
+              key={tabId}
+              onPress={() => setActiveTab(tabId)}
               className="flex-1 items-center pb-3 pt-2"
               style={isActive ? { borderBottomWidth: 2, borderBottomColor: COLORS.primary } : {}}>
               <Text
                 className="text-lg font-bold"
                 style={{ color: isActive ? COLORS.primary : COLORS.textMuted }}>
-                {tab.count}
+                {grouped[tabId].length}
               </Text>
               <Text
                 className="text-sm font-medium"
                 style={{ color: isActive ? COLORS.primary : COLORS.textMuted }}>
-                {tab.label}
+                {TAB_LABELS[tabId]}
               </Text>
             </TouchableOpacity>
           );
@@ -138,36 +121,45 @@ export default function SaleHistory() {
       </View>
 
       {/* 리스트 */}
-      <ScrollView className="flex-1 px-4" showsVerticalScrollIndicator={false}>
-        {items.map((item) => (
-          <View key={item.id} className="mb-4 rounded-2xl bg-white p-3" style={SHADOWS.card}>
-            <View className="flex-row">
-              {/* 상품 이미지 */}
-              <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
-                {item.image ? (
-                  <Image
-                    source={{ uri: item.image }}
-                    className="h-full w-full"
-                    resizeMode="cover"
-                  />
-                ) : (
-                  <View className="h-full w-full items-center justify-center bg-gray-200">
-                    <MaterialCommunityIcons name="image-outline" size={32} color="#9CA3AF" />
-                  </View>
-                )}
-              </View>
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color={COLORS.primary} />
+        </View>
+      ) : (
+        <ScrollView className="flex-1 px-4" showsVerticalScrollIndicator={false}>
+          {items.map((item) => (
+            <TouchableOpacity
+              key={item.product_id}
+              className="mb-4 rounded-2xl bg-white p-3"
+              style={SHADOWS.card}
+              activeOpacity={0.7}
+              onPress={() => router.push(`/product/${item.product_id}`)}>
+              <View className="flex-row">
+                {/* 상품 이미지 */}
+                <View className="relative mr-3 h-24 w-24 overflow-hidden rounded-xl bg-gray-100">
+                  {item.media_url ? (
+                    <Image
+                      source={{ uri: item.media_url }}
+                      className="h-full w-full"
+                      resizeMode="cover"
+                    />
+                  ) : (
+                    <View className="h-full w-full items-center justify-center bg-gray-200">
+                      <MaterialCommunityIcons name="image-outline" size={32} color="#9CA3AF" />
+                    </View>
+                  )}
+                </View>
 
-              {/* 상품 정보 */}
-              <View className="flex-1">
-                <Text
-                  className="mb-1 text-base font-bold text-gray-900"
-                  numberOfLines={1}
-                  ellipsizeMode="tail">
-                  {item.name}
-                </Text>
+                {/* 상품 정보 */}
+                <View className="flex-1">
+                  <Text
+                    className="mb-1 text-base font-bold text-gray-900"
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
+                    {item.title}
+                  </Text>
 
-                {/* 남은 시간 또는 날짜 */}
-                {item.endTime ? (
+                  {/* 남은 시간 */}
                   <View className="mb-3 flex-row items-center">
                     <MaterialCommunityIcons
                       name="clock-outline"
@@ -175,56 +167,45 @@ export default function SaleHistory() {
                       color={COLORS.textMuted}
                     />
                     <Text className="ml-1 text-xs text-gray-500">
-                      {formatRemainingTime(item.endTime)}
-                    </Text>
-                  </View>
-                ) : (
-                  <View className="mb-3 flex-row items-center">
-                    <Text className="text-xs text-gray-500">{item.date}</Text>
-                  </View>
-                )}
-
-                {/* 가격 정보 */}
-                <View className="flex-row items-center">
-                  {/* 시작가 */}
-                  <View className="mr-2 flex-1 items-center rounded-lg bg-gray-100 px-2.5 py-1.5">
-                    <Text className="text-xs text-gray-500">시작가</Text>
-                    <Text className="text-xs font-bold text-gray-700">
-                      {formatPrice(item.originalPrice)}원
+                      {formatRemainingTime(item.end_time)}
                     </Text>
                   </View>
 
-                  {/* 현재가 */}
+                  {/* 가격 정보 */}
                   <View
-                    className="flex-1 items-center rounded-lg px-2.5 py-1.5"
+                    className="items-center self-start rounded-lg px-4 py-1.5"
                     style={{ backgroundColor: COLORS.primary }}>
                     <Text className="text-xs text-white">현재가</Text>
                     <Text className="text-xs font-bold text-white">
-                      {formatPrice(item.currentPrice)}원
+                      {formatPrice(item.current_price)}원
                     </Text>
                   </View>
                 </View>
               </View>
+
+              {/* 참여자 수 */}
+              {item.bid_count > 0 && (
+                <View className="mt-2 flex-row items-center pl-1">
+                  <MaterialCommunityIcons
+                    name="account-outline"
+                    size={14}
+                    color={COLORS.textMuted}
+                  />
+                  <Text className="ml-1 text-xs text-gray-500">{item.bid_count}명 참여중</Text>
+                </View>
+              )}
+            </TouchableOpacity>
+          ))}
+
+          {items.length === 0 && (
+            <View className="items-center pt-20">
+              <Text className="text-gray-400">내역이 없습니다</Text>
             </View>
+          )}
 
-            {/* 참여자 수 */}
-            {item.participants != null && (
-              <View className="mt-2 flex-row items-center pl-1">
-                <MaterialCommunityIcons name="account-outline" size={14} color={COLORS.textMuted} />
-                <Text className="ml-1 text-xs text-gray-500">{item.participants}명 참여중</Text>
-              </View>
-            )}
-          </View>
-        ))}
-
-        {items.length === 0 && (
-          <View className="items-center pt-20">
-            <Text className="text-gray-400">내역이 없습니다</Text>
-          </View>
-        )}
-
-        <View className="h-8" />
-      </ScrollView>
+          <View className="h-8" />
+        </ScrollView>
+      )}
     </SafeAreaView>
   );
 }

--- a/hooks/auth/useLoginMutation.ts
+++ b/hooks/auth/useLoginMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { loginApi } from '@/api/auth';
-import { setRefreshToken, setStoredUserId } from '@/lib/secureStore';
+import { setRefreshToken, setStoredUserId, setStoredUserName } from '@/lib/secureStore';
 import { useAuthActions } from '@/store/useAuthStore';
 
 function readStringCandidate(source: Record<string, unknown>, keys: string[]) {
@@ -68,10 +68,15 @@ export function useLoginMutation() {
         throw new Error('로그인 응답의 userId 형식이 올바르지 않습니다.');
       }
 
+      const userName =
+        (nestedData && readStringCandidate(nestedData, ['userName', 'user_name', 'name'])) ??
+        readStringCandidate(responseRecord, ['userName', 'user_name', 'name']);
+
       // 로그인 성공 시 RT는 SecureStore, AT는 메모리 상태로 분리 저장합니다.
       await setRefreshToken(refreshToken);
       await setStoredUserId(userId);
-      setSession({ userId, accessToken });
+      if (userName) await setStoredUserName(userName);
+      setSession({ userId, accessToken, userName });
     },
   });
 }

--- a/hooks/user/useDeleteUserMutation.ts
+++ b/hooks/user/useDeleteUserMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { deleteUserApi } from '@/api/user';
+import useAuthStore from '@/store/useAuthStore';
+import { getRefreshToken } from '@/lib/secureStore';
+
+export function useDeleteUserMutation() {
+  return useMutation({
+    mutationFn: async () => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      const refreshToken = await getRefreshToken();
+      if (!refreshToken) throw new Error('Refresh Token이 없습니다.');
+      return deleteUserApi(token, refreshToken);
+    },
+  });
+}

--- a/hooks/user/useUpdateUserProfileMutation.ts
+++ b/hooks/user/useUpdateUserProfileMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateUserProfileApi } from '@/api/user';
+import type { UpdateUserProfileRequest } from '@/api/types';
+import useAuthStore from '@/store/useAuthStore';
+
+export function useUpdateUserProfileMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateUserProfileRequest) => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return updateUserProfileApi(body, token);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+    },
+  });
+}

--- a/hooks/user/useUserProfileQuery.ts
+++ b/hooks/user/useUserProfileQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getUserProfileApi } from '@/api/user';
+import useAuthStore, { useIsLoggedIn } from '@/store/useAuthStore';
+
+export function useUserProfileQuery() {
+  const isLoggedIn = useIsLoggedIn();
+
+  return useQuery({
+    queryKey: ['userProfile'],
+    queryFn: () => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return getUserProfileApi(token);
+    },
+    select: (response) => response.data,
+    enabled: isLoggedIn,
+  });
+}

--- a/lib/secureStore.ts
+++ b/lib/secureStore.ts
@@ -2,6 +2,7 @@ import * as SecureStore from 'expo-secure-store';
 
 const REFRESH_TOKEN_KEY = 'batchar_refresh_token';
 const USER_ID_KEY = 'batchar_user_id';
+const USER_NAME_KEY = 'batchar_user_name';
 
 export async function setRefreshToken(refreshToken: string) {
   await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
@@ -32,4 +33,16 @@ export async function getStoredUserId() {
 
 export async function removeStoredUserId() {
   await SecureStore.deleteItemAsync(USER_ID_KEY);
+}
+
+export async function setStoredUserName(userName: string) {
+  await SecureStore.setItemAsync(USER_NAME_KEY, userName);
+}
+
+export async function getStoredUserName() {
+  return SecureStore.getItemAsync(USER_NAME_KEY);
+}
+
+export async function removeStoredUserName() {
+  await SecureStore.deleteItemAsync(USER_NAME_KEY);
 }

--- a/store/useAuthStore.ts
+++ b/store/useAuthStore.ts
@@ -5,15 +5,19 @@ import { logoutApi, refreshApi } from '@/api/auth';
 import {
   getRefreshToken,
   getStoredUserId,
+  getStoredUserName,
   removeRefreshToken,
   removeStoredUserId,
+  removeStoredUserName,
   setRefreshToken,
+  setStoredUserName,
 } from '@/lib/secureStore';
 
 type AuthStatus = 'idle' | 'authenticated' | 'unauthenticated';
 
 type AuthStoreState = {
   userId: number | null;
+  userName: string | null;
   accessToken: string | null;
   status: AuthStatus;
   isInitialized: boolean;
@@ -21,6 +25,7 @@ type AuthStoreState = {
 
 const initialState: AuthStoreState = {
   userId: null,
+  userName: null,
   accessToken: null,
   status: 'idle' as AuthStatus,
   // 초기 세션 복원이 끝나기 전에는 라우팅을 보류합니다.
@@ -32,16 +37,26 @@ const useAuthStore = create(
     immer(
       combine(initialState, (set) => ({
         actions: {
-          setSession: ({ userId, accessToken }: { userId: number; accessToken: string }) =>
+          setSession: ({
+            userId,
+            accessToken,
+            userName,
+          }: {
+            userId: number;
+            accessToken: string;
+            userName?: string | null;
+          }) =>
             set((state) => {
               state.userId = userId;
               state.accessToken = accessToken;
               state.status = 'authenticated';
+              if (userName) state.userName = userName;
             }),
 
           clearSession: () =>
             set((state) => {
               state.userId = null;
+              state.userName = null;
               state.accessToken = null;
               state.status = 'unauthenticated';
             }),
@@ -51,10 +66,12 @@ const useAuthStore = create(
               // 앱 재실행 시에는 저장된 RT와 userId로 세션을 복구합니다.
               const refreshToken = await getRefreshToken();
               const storedUserId = await getStoredUserId();
+              const storedUserName = await getStoredUserName();
 
               if (!refreshToken || storedUserId === null) {
                 set((state) => {
                   state.userId = null;
+                  state.userName = null;
                   state.accessToken = null;
                   state.status = 'unauthenticated';
                   state.isInitialized = true;
@@ -70,6 +87,7 @@ const useAuthStore = create(
 
               set((state) => {
                 state.userId = storedUserId;
+                state.userName = storedUserName;
                 state.accessToken = accessToken;
                 state.status = 'authenticated';
                 state.isInitialized = true;
@@ -78,9 +96,11 @@ const useAuthStore = create(
               // 세션 복구에 실패하면 저장된 RT를 제거하고 비로그인 상태로 전환합니다.
               await removeRefreshToken();
               await removeStoredUserId();
+              await removeStoredUserName();
 
               set((state) => {
                 state.userId = null;
+                state.userName = null;
                 state.accessToken = null;
                 state.status = 'unauthenticated';
                 state.isInitialized = true;
@@ -100,9 +120,11 @@ const useAuthStore = create(
             } finally {
               await removeRefreshToken();
               await removeStoredUserId();
+              await removeStoredUserName();
 
               set((state) => {
                 state.userId = null;
+                state.userName = null;
                 state.accessToken = null;
                 state.status = 'unauthenticated';
               });
@@ -119,6 +141,7 @@ export default useAuthStore;
 
 export const useAuthStatus = () => useAuthStore((state) => state.status);
 export const useAccessToken = () => useAuthStore((state) => state.accessToken);
+export const useUserName = () => useAuthStore((state) => state.userName);
 export const useIsInitialized = () => useAuthStore((state) => state.isInitialized);
 export const useIsLoggedIn = () => useAuthStore((state) => state.status === 'authenticated');
 export const useAuthActions = () => useAuthStore((state) => state.actions);


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 마이페이지 API 연동 및 mock 데이터 제거 작업을 진행하였습니다.

## 📝 변경 사항 요약 (Summary)

- 구매/판매 내역: MY_BIDS, MY_PRODUCTS API 연동 및 상태별 탭 필터링
- 프로필 조회: GET /api/users/me 연동 (닉네임, 이메일, 주소, 프로필 이미지)
- 프로필 수정: PATCH /api/users/me 연동 (닉네임 변경, 주소 변경)
- 회원 탈퇴: DELETE /api/users/me 연동
- 상품 카드 클릭 시 상세 페이지 라우팅 추가
- authStore에 userName 필드 추가 및 secureStore 영속화

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #58 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)