### PR TITLE
#58 feat(mypage): 프로필 이미지 변경/삭제 및 비밀번호 변경 API 연동

### DIFF
--- a/api/types.ts
+++ b/api/types.ts
@@ -80,6 +80,22 @@ export type UpdateUserProfileResponse = ApiResponse<UserProfile>;
 
 export type DeleteUserResponse = ApiResponse<null>;
 
+export type UpdateProfileImageResponse = ApiResponse<UserProfile>;
+export type DeleteProfileImageResponse = ApiResponse<null>;
+
+export type PasswordVerifyRequest = {
+  password: string;
+};
+
+export type PasswordVerifyResponse = ApiResponse<null>;
+
+export type ChangePasswordRequest = {
+  current_password: string;
+  new_password: string;
+};
+
+export type ChangePasswordResponse = ApiResponse<null>;
+
 // ── Product ──
 
 export type ProductCreateRequest = {

--- a/api/user.ts
+++ b/api/user.ts
@@ -1,6 +1,12 @@
 import { apiFetch } from './client';
 import type {
+  ChangePasswordRequest,
+  ChangePasswordResponse,
+  DeleteProfileImageResponse,
   DeleteUserResponse,
+  PasswordVerifyRequest,
+  PasswordVerifyResponse,
+  UpdateProfileImageResponse,
   UpdateUserProfileRequest,
   UpdateUserProfileResponse,
   UserProfileResponse,
@@ -22,6 +28,82 @@ export function deleteUserApi(accessToken: string, refreshToken: string) {
   return apiFetch<DeleteUserResponse>('/api/users/me', {
     method: 'DELETE',
     headers: { 'Refresh-Token': refreshToken },
+    accessToken,
+  });
+}
+
+// ── 프로필 이미지 ──
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.trim().replace(/\/+$/, '') ?? '';
+
+export async function updateProfileImageApi(
+  imageUri: string,
+  accessToken: string
+): Promise<UpdateProfileImageResponse> {
+  if (!BASE_URL) {
+    throw new Error('EXPO_PUBLIC_API_BASE_URL이 없습니다. Metro 서버를 재시작해 주세요.');
+  }
+
+  const name = imageUri.split('/').pop() ?? 'profile.jpg';
+  const ext = name.split('.').pop()?.toLowerCase() ?? 'jpg';
+  const mimeMap: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+  };
+
+  const formData = new FormData();
+  formData.append('image', {
+    uri: imageUri,
+    name,
+    type: mimeMap[ext] ?? 'image/jpeg',
+  } as unknown as Blob);
+
+  const response = await fetch(`${BASE_URL}/api/users/me/profile-image`, {
+    method: 'PATCH',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: formData,
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+  const data = isJson ? await response.json() : null;
+
+  if (!response.ok) {
+    const message = data?.message ?? `프로필 이미지 변경에 실패했습니다. status=${response.status}`;
+    throw new Error(message);
+  }
+
+  return data as UpdateProfileImageResponse;
+}
+
+export function deleteProfileImageApi(accessToken: string) {
+  return apiFetch<DeleteProfileImageResponse>('/api/users/me/profile-image', {
+    method: 'DELETE',
+    accessToken,
+  });
+}
+
+// ── 비밀번호 ──
+
+export function verifyPasswordApi(body: PasswordVerifyRequest, accessToken: string) {
+  return apiFetch<PasswordVerifyResponse>('/api/users/me/password/verify', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    accessToken,
+  });
+}
+
+export function changePasswordApi(body: ChangePasswordRequest, accessToken: string) {
+  return apiFetch<ChangePasswordResponse>('/api/users/me/password', {
+    method: 'PATCH',
+    body: JSON.stringify(body),
     accessToken,
   });
 }

--- a/app/mypage/change-password.tsx
+++ b/app/mypage/change-password.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react';
-import { View, Text, TextInput, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, TextInput, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { COLORS } from '@/constants/theme';
+import { useVerifyPasswordMutation } from '@/hooks/user/useVerifyPasswordMutation';
+import { useChangePasswordMutation } from '@/hooks/user/useChangePasswordMutation';
 
 export default function ChangePassword() {
   const router = useRouter();
+  const verifyPasswordMutation = useVerifyPasswordMutation();
+  const changePasswordMutation = useChangePasswordMutation();
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -21,7 +25,10 @@ export default function ChangePassword() {
     newPassword.length === 0 || (newPassword.length >= 8 && newPassword.length <= 30);
   const isConfirmMatch = confirmPassword.length === 0 || newPassword === confirmPassword;
 
+  const isLoading = verifyPasswordMutation.isPending || changePasswordMutation.isPending;
+
   const canSubmit =
+    !isLoading &&
     currentPassword.length > 0 &&
     newPassword.length >= 8 &&
     newPassword.length <= 30 &&
@@ -29,8 +36,30 @@ export default function ChangePassword() {
 
   const handleSubmit = () => {
     if (!canSubmit) return;
-    // TODO: 비밀번호 변경 API 연동
-    router.back();
+
+    verifyPasswordMutation.mutate(
+      { password: currentPassword },
+      {
+        onSuccess: () => {
+          changePasswordMutation.mutate(
+            { current_password: currentPassword, new_password: newPassword },
+            {
+              onSuccess: () => {
+                Alert.alert('완료', '비밀번호가 변경되었습니다.', [
+                  { text: '확인', onPress: () => router.back() },
+                ]);
+              },
+              onError: (error) => {
+                Alert.alert('오류', error.message);
+              },
+            }
+          );
+        },
+        onError: (error) => {
+          Alert.alert('오류', error.message);
+        },
+      }
+    );
   };
 
   return (
@@ -139,7 +168,9 @@ export default function ChangePassword() {
           style={{ backgroundColor: COLORS.primary, opacity: canSubmit ? 1 : 0.5 }}
           disabled={!canSubmit}
           onPress={handleSubmit}>
-          <Text className="text-base font-bold text-white">비밀번호 변경하기</Text>
+          <Text className="text-base font-bold text-white">
+            {isLoading ? '처리 중...' : '비밀번호 변경하기'}
+          </Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>

--- a/app/mypage/edit-profile.tsx
+++ b/app/mypage/edit-profile.tsx
@@ -1,10 +1,21 @@
-import { View, Text, ScrollView, TouchableOpacity, Image, ActivityIndicator } from 'react-native';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
 import { COLORS } from '@/constants/theme';
 import TabBar from '@/components/layout/TabBar';
 import { useUserProfileQuery } from '@/hooks/user/useUserProfileQuery';
+import { useUpdateProfileImageMutation } from '@/hooks/user/useUpdateProfileImageMutation';
+import { useDeleteProfileImageMutation } from '@/hooks/user/useDeleteProfileImageMutation';
 
 type ProfileField = {
   label: string;
@@ -15,6 +26,46 @@ type ProfileField = {
 export default function EditProfile() {
   const router = useRouter();
   const { data: profile, isLoading } = useUserProfileQuery();
+  const updateImageMutation = useUpdateProfileImageMutation();
+  const deleteImageMutation = useDeleteProfileImageMutation();
+
+  const handleProfileImagePress = () => {
+    const options = profile?.profile_image_url
+      ? [
+          { text: '앨범에서 선택', onPress: pickImage },
+          { text: '기본 이미지로 변경', onPress: handleDeleteImage },
+          { text: '취소', style: 'cancel' as const },
+        ]
+      : [
+          { text: '앨범에서 선택', onPress: pickImage },
+          { text: '취소', style: 'cancel' as const },
+        ];
+
+    Alert.alert('프로필 사진', '변경 방법을 선택해주세요.', options);
+  };
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+
+    if (result.canceled || !result.assets[0]) return;
+
+    updateImageMutation.mutate(result.assets[0].uri, {
+      onError: (error) => Alert.alert('오류', error.message),
+    });
+  };
+
+  const handleDeleteImage = () => {
+    deleteImageMutation.mutate(undefined, {
+      onError: (error) => Alert.alert('오류', error.message),
+    });
+  };
+
+  const isImageLoading = updateImageMutation.isPending || deleteImageMutation.isPending;
 
   const fields: ProfileField[] = [
     { label: '이메일', value: profile?.email ?? '' },
@@ -44,11 +95,16 @@ export default function EditProfile() {
         <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
           {/* 프로필 이미지 */}
           <View className="items-center pb-6 pt-4">
-            <View style={{ width: 96, height: 96 }}>
+            <TouchableOpacity
+              style={{ width: 96, height: 96 }}
+              onPress={handleProfileImagePress}
+              disabled={isImageLoading}>
               <View
                 className="h-24 w-24 items-center justify-center overflow-hidden rounded-full"
                 style={{ backgroundColor: COLORS.primary }}>
-                {profile?.profile_image_url ? (
+                {isImageLoading ? (
+                  <ActivityIndicator size="small" color="white" />
+                ) : profile?.profile_image_url ? (
                   <Image
                     source={{ uri: profile.profile_image_url }}
                     className="h-full w-full"
@@ -62,13 +118,13 @@ export default function EditProfile() {
                     style={{ marginTop: -8 }}
                   />
                 )}
-                <TouchableOpacity
+                <View
                   className="absolute bottom-0 left-0 right-0 items-center py-1.5"
                   style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}>
                   <Text className="text-xs font-semibold text-white">편집</Text>
-                </TouchableOpacity>
+                </View>
               </View>
-            </View>
+            </TouchableOpacity>
           </View>
 
           {/* 프로필 정보 */}

--- a/hooks/user/useChangePasswordMutation.ts
+++ b/hooks/user/useChangePasswordMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { changePasswordApi } from '@/api/user';
+import type { ChangePasswordRequest } from '@/api/types';
+import useAuthStore from '@/store/useAuthStore';
+
+export function useChangePasswordMutation() {
+  return useMutation({
+    mutationFn: (body: ChangePasswordRequest) => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return changePasswordApi(body, token);
+    },
+  });
+}

--- a/hooks/user/useDeleteProfileImageMutation.ts
+++ b/hooks/user/useDeleteProfileImageMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteProfileImageApi } from '@/api/user';
+import useAuthStore from '@/store/useAuthStore';
+
+export function useDeleteProfileImageMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return deleteProfileImageApi(token);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+    },
+  });
+}

--- a/hooks/user/useUpdateProfileImageMutation.ts
+++ b/hooks/user/useUpdateProfileImageMutation.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateProfileImageApi } from '@/api/user';
+import useAuthStore from '@/store/useAuthStore';
+
+export function useUpdateProfileImageMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (imageUri: string) => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return updateProfileImageApi(imageUri, token);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+    },
+  });
+}

--- a/hooks/user/useVerifyPasswordMutation.ts
+++ b/hooks/user/useVerifyPasswordMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { verifyPasswordApi } from '@/api/user';
+import type { PasswordVerifyRequest } from '@/api/types';
+import useAuthStore from '@/store/useAuthStore';
+
+export function useVerifyPasswordMutation() {
+  return useMutation({
+    mutationFn: (body: PasswordVerifyRequest) => {
+      const token = useAuthStore.getState().accessToken;
+      if (!token) throw new Error('인증 토큰이 없습니다.');
+      return verifyPasswordApi(body, token);
+    },
+  });
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 프로필 이미지 변경/삭제 및 비밀번호 변경 API 연동을 진행하였습니다.

## 📝 변경 사항 요약 (Summary)

- 프로필 이미지 업로드 및 삭제 API 함수, 타입, 훅 추가
- 비밀번호 확인 및 변경 API 함수, 타입, 훅 추가
- edit-profile.tsx: 이미지 피커 + 업로드/삭제 ActionSheet 연동
- change-password.tsx: 비밀번호 확인 → 변경 2단계 API 연동

## 🔗 관련 이슈 (Related Issues)

- Closes #None
- Related #58

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)