### PR TITLE
#43, #55, #58, feature(chat, product): 채팅 액션 기능 및 실시간 경매 업데이트 구현

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,10 +1,22 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import { ImagePickerAsset } from 'expo-image-picker';
+
 import { apiFetch } from './client';
 import {
+  ChatCompleteDealResponse,
+  ChatLeaveResponse,
   ChatListResponse,
+  ChatMediaSendResponse,
   ChatMessageRequest,
   ChatMessageSendResponse,
   ChatMessagesResponse,
 } from './types';
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.trim().replace(/\/+$/, '') ?? '';
 
 export async function getChatListApi(accessToken: string): Promise<ChatListResponse> {
   return apiFetch<ChatListResponse>('/api/chats', { accessToken });
@@ -27,4 +39,77 @@ export async function sendMessageApi(
     body: JSON.stringify(request),
     accessToken,
   });
+}
+
+export async function leaveChatApi(
+  chatId: number,
+  accessToken: string
+): Promise<ChatLeaveResponse> {
+  return apiFetch<ChatLeaveResponse>(`/api/chats/${chatId}`, {
+    method: 'DELETE',
+    accessToken,
+  });
+}
+
+export async function completeDealApi(
+  chatId: number,
+  accessToken: string
+): Promise<ChatCompleteDealResponse> {
+  return apiFetch<ChatCompleteDealResponse>(`/api/chats/${chatId}/complete`, {
+    method: 'POST',
+    accessToken,
+  });
+}
+
+export async function sendChatMediaApi(
+  chatId: number,
+  file: ImagePickerAsset,
+  accessToken: string
+): Promise<ChatMediaSendResponse> {
+  if (!BASE_URL) {
+    throw new Error('EXPO_PUBLIC_API_BASE_URL이 없습니다. Metro 서버를 재시작해 주세요.');
+  }
+
+  const formData = new FormData();
+
+  const uri = file.uri;
+  const name = uri.split('/').pop() ?? 'file';
+  const ext = name.split('.').pop()?.toLowerCase() ?? 'jpg';
+
+  const mimeMap: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    mp4: 'video/mp4',
+    mov: 'video/quicktime',
+    avi: 'video/x-msvideo',
+    webm: 'video/webm',
+  };
+
+  formData.append('file', {
+    uri,
+    name,
+    type: mimeMap[ext] ?? 'image/jpeg',
+  } as unknown as Blob);
+
+  const response = await fetch(`${BASE_URL}/api/chats/${chatId}/media`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: formData,
+  });
+
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+  const data = isJson ? await response.json() : null;
+
+  if (!response.ok) {
+    const message = data?.message ?? `미디어 전송에 실패했습니다. status=${response.status}`;
+    throw new Error(message);
+  }
+
+  return data as ChatMediaSendResponse;
 }

--- a/api/storage.ts
+++ b/api/storage.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from './client';
+import { PresignedUrlRequest, PresignedUrlResponse } from './types';
+
+export async function getPresignedUrlApi(
+  request: PresignedUrlRequest,
+  accessToken: string
+): Promise<PresignedUrlResponse> {
+  return apiFetch<PresignedUrlResponse>('/api/storage/presigned-url', {
+    method: 'POST',
+    body: JSON.stringify(request),
+    accessToken,
+  });
+}
+
+export async function uploadToPresignedUrl(
+  presignedUrl: string,
+  fileUri: string,
+  contentType: string
+): Promise<void> {
+  const response = await fetch(fileUri);
+  const blob = await response.blob();
+
+  const uploadResponse = await fetch(presignedUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': contentType,
+    },
+    body: blob,
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error(`파일 업로드에 실패했습니다. status=${uploadResponse.status}`);
+  }
+}

--- a/api/types.ts
+++ b/api/types.ts
@@ -239,6 +239,27 @@ export type BidListResponse = ApiResponse<{
   has_next: boolean;
 }>;
 
+// ── SSE ──
+
+export type BidBroadcast = {
+  productId: number;
+  currentPrice: number;
+  bidderName: string;
+  createdAt: string;
+};
+
+// ── Storage ──
+
+export type PresignedUrlRequest = {
+  fileName: string;
+  contentType: string;
+};
+
+export type PresignedUrlResponse = ApiResponse<{
+  presignedUrl: string;
+  objectUrl: string;
+}>;
+
 // ── Chat ──
 
 export type ChatListItem = {
@@ -268,3 +289,19 @@ export type ChatMessage = {
 export type ChatMessagesResponse = ApiResponse<ChatMessage[]>;
 
 export type ChatMessageSendResponse = ApiResponse<ChatMessage>;
+
+export type ChatLeaveResponse = ApiResponse<null>;
+
+export type ChatCompleteDealResponse = ApiResponse<null>;
+
+export type ChatMediaMessage = {
+  message_id: number;
+  sender_id: number;
+  content: string;
+  media_url: string;
+  media_type: 'IMAGE' | 'VIDEO';
+  is_read: boolean;
+  created_at: string;
+};
+
+export type ChatMediaSendResponse = ApiResponse<ChatMediaMessage>;

--- a/api/types.ts
+++ b/api/types.ts
@@ -270,6 +270,8 @@ export type ChatListItem = {
   last_message: string;
   unread_count: number;
   updated_at: string;
+  my_confirmed: boolean;
+  partner_confirmed: boolean;
 };
 
 export type ChatListResponse = ApiResponse<ChatListItem[]>;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,11 +2,21 @@ import '../global.css';
 import { Stack, useRouter, useSegments, useRootNavigationState } from 'expo-router';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useEffect } from 'react';
-import { ActivityIndicator, View } from 'react-native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ActivityIndicator, AppState, Platform, View } from 'react-native';
+import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
 import { useAuthActions, useIsInitialized, useIsLoggedIn } from '@/store/useAuthStore';
 import { COLORS } from '@/constants/theme';
+
+// React Native에서 앱이 포그라운드로 돌아올 때 refetchOnWindowFocus 동작을 위한 설정
+focusManager.setEventListener((handleFocus) => {
+  const subscription = AppState.addEventListener('change', (state) => {
+    if (Platform.OS !== 'web') {
+      handleFocus(state === 'active');
+    }
+  });
+  return () => subscription.remove();
+});
 
 // ──────────────────────────────────────────────────────────────────
 // 라우트 가드 컴포넌트

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -25,6 +25,7 @@ import { useStompClient } from '@/hooks/chat/useStompClient';
 import { useLeaveChatMutation } from '@/hooks/chat/useLeaveChatMutation';
 import { useCompleteDealMutation } from '@/hooks/chat/useCompleteDealMutation';
 import { useSendChatMediaMutation } from '@/hooks/chat/useSendChatMediaMutation';
+import { useDealStatus } from '@/hooks/chat/useDealStatus';
 import { COLORS, ICON_SIZES } from '@/constants/theme';
 import useAuthStore from '@/store/useAuthStore';
 
@@ -87,12 +88,12 @@ export default function ChatDetail() {
   const { data: chatList } = useChatListQuery();
   const { data: messages, isLoading } = useChatMessagesQuery(chatId);
 
-  const [dealCompleted, setDealCompleted] = useState(false);
   const { mutate: sendMessageHttp, isPending: isSending } = useSendMessageMutation();
   const { mutate: leaveChat, isPending: isLeaving } = useLeaveChatMutation();
   const { mutate: completeDeal, isPending: isCompleting } = useCompleteDealMutation();
   const { mutate: sendMedia, isPending: isSendingMedia } = useSendChatMediaMutation();
   const chatInfo = chatList?.find((c) => c.chat_id === chatId);
+  const { dealCompleted, markMyConfirmed } = useDealStatus(chatId);
 
   const onMessageReceived = useCallback(() => {
     setTimeout(() => scrollViewRef.current?.scrollToEnd({ animated: true }), 100);
@@ -166,7 +167,7 @@ export default function ChatDetail() {
         onPress: () => {
           completeDeal(chatId, {
             onSuccess: () => {
-              setDealCompleted(true);
+              markMyConfirmed();
               Alert.alert(
                 '거래 완료 확인',
                 '거래 완료를 확인했습니다.\n상대방도 거래 완료를 확인해야 최종 완료됩니다.'

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -7,15 +7,24 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Alert,
+  Modal,
+  Image,
+  Animated,
+  StyleSheet,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import { useChatMessagesQuery } from '@/hooks/chat/useChatMessagesQuery';
 import { useSendMessageMutation } from '@/hooks/chat/useSendMessageMutation';
 import { useChatListQuery } from '@/hooks/chat/useChatListQuery';
 import { useStompClient } from '@/hooks/chat/useStompClient';
+import { useLeaveChatMutation } from '@/hooks/chat/useLeaveChatMutation';
+import { useCompleteDealMutation } from '@/hooks/chat/useCompleteDealMutation';
+import { useSendChatMediaMutation } from '@/hooks/chat/useSendChatMediaMutation';
 import { COLORS, ICON_SIZES } from '@/constants/theme';
 import useAuthStore from '@/store/useAuthStore';
 
@@ -52,13 +61,37 @@ export default function ChatDetail() {
   const router = useRouter();
   const [messageText, setMessageText] = useState('');
   const scrollViewRef = useRef<ScrollView>(null);
+  const [showMenu, setShowMenu] = useState(false);
+  const sheetAnim = useRef(new Animated.Value(0)).current;
+  const SHEET_HEIGHT = 200;
+
+  const openMenu = () => {
+    setShowMenu(true);
+    Animated.timing(sheetAnim, {
+      toValue: 1,
+      duration: 250,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const closeMenu = () => {
+    Animated.timing(sheetAnim, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => setShowMenu(false));
+  };
 
   const chatId = Number(id) || 0;
   const userId = useAuthStore((state) => state.userId);
   const { data: chatList } = useChatListQuery();
   const { data: messages, isLoading } = useChatMessagesQuery(chatId);
 
+  const [dealCompleted, setDealCompleted] = useState(false);
   const { mutate: sendMessageHttp, isPending: isSending } = useSendMessageMutation();
+  const { mutate: leaveChat, isPending: isLeaving } = useLeaveChatMutation();
+  const { mutate: completeDeal, isPending: isCompleting } = useCompleteDealMutation();
+  const { mutate: sendMedia, isPending: isSendingMedia } = useSendChatMediaMutation();
   const chatInfo = chatList?.find((c) => c.chat_id === chatId);
 
   const onMessageReceived = useCallback(() => {
@@ -98,6 +131,84 @@ export default function ChatDetail() {
     }
   };
 
+  const handleLeaveChat = () => {
+    if (!dealCompleted) {
+      closeMenu();
+      Alert.alert('알림', '거래가 완료된 후에 채팅방을 나갈 수 있습니다.');
+      return;
+    }
+    closeMenu();
+    Alert.alert('채팅방 나가기', '정말 이 채팅방을 나가시겠습니까?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '나가기',
+        style: 'destructive',
+        onPress: () => {
+          leaveChat(chatId, {
+            onSuccess: () => {
+              router.replace('/chat');
+            },
+            onError: (error) => {
+              Alert.alert('오류', error.message);
+            },
+          });
+        },
+      },
+    ]);
+  };
+
+  const handleCompleteDeal = () => {
+    closeMenu();
+    Alert.alert('거래 완료', '거래를 완료하시겠습니까?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '완료',
+        onPress: () => {
+          completeDeal(chatId, {
+            onSuccess: () => {
+              setDealCompleted(true);
+              Alert.alert(
+                '거래 완료 확인',
+                '거래 완료를 확인했습니다.\n상대방도 거래 완료를 확인해야 최종 완료됩니다.'
+              );
+            },
+            onError: (error) => {
+              Alert.alert('오류', error.message);
+            },
+          });
+        },
+      },
+    ]);
+  };
+
+  const handlePickMedia = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('권한 필요', '사진 라이브러리 접근 권한이 필요합니다.');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images', 'videos'],
+      allowsMultipleSelection: false,
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets.length > 0) {
+      sendMedia(
+        { chatId, file: result.assets[0] },
+        {
+          onSuccess: () => {
+            setTimeout(() => scrollViewRef.current?.scrollToEnd({ animated: true }), 200);
+          },
+          onError: (error) => {
+            Alert.alert('전송 실패', error.message);
+          },
+        }
+      );
+    }
+  };
+
   if (isLoading) {
     return (
       <SafeAreaView className="flex-1 bg-white" edges={['top']}>
@@ -119,21 +230,112 @@ export default function ChatDetail() {
 
   const getDateKey = (createdAt: string) => new Date(createdAt).toDateString();
 
+  const isMediaMessage = (content: string) => {
+    return /\.(jpg|jpeg|png|gif|webp|mp4|mov|avi|webm)$/i.test(content);
+  };
+
+  const isVideoUrl = (url: string) => {
+    return /\.(mp4|mov|avi|webm)$/i.test(url);
+  };
+
   return (
     <SafeAreaView className="flex-1 bg-white" edges={['top', 'bottom']}>
       {/* 헤더 */}
       <View
-        className="flex-row items-center px-4 py-3"
+        className="flex-row items-center justify-between px-4 py-3"
         style={{ borderBottomWidth: 1, borderBottomColor: COLORS.border }}>
-        <TouchableOpacity onPress={() => router.back()}>
-          <MaterialCommunityIcons name="chevron-left" size={ICON_SIZES.lg} color={COLORS.primary} />
-        </TouchableOpacity>
-        <View className="ml-2">
-          <Text className="text-lg font-bold" style={{ color: COLORS.text }}>
-            {chatInfo?.partner_name ?? '채팅'}
-          </Text>
+        <View className="flex-row items-center">
+          <TouchableOpacity onPress={() => router.back()}>
+            <MaterialCommunityIcons
+              name="chevron-left"
+              size={ICON_SIZES.lg}
+              color={COLORS.primary}
+            />
+          </TouchableOpacity>
+          <View className="ml-2">
+            <Text className="text-lg font-bold" style={{ color: COLORS.text }}>
+              {chatInfo?.partner_name ?? '채팅'}
+            </Text>
+          </View>
         </View>
+        <TouchableOpacity onPress={openMenu}>
+          <MaterialCommunityIcons name="dots-vertical" size={ICON_SIZES.md} color={COLORS.text} />
+        </TouchableOpacity>
       </View>
+
+      {/* 하단 바텀시트 메뉴 */}
+      <Modal visible={showMenu} transparent animationType="none" onRequestClose={closeMenu}>
+        <View className="flex-1">
+          {/* 딤 배경 (페이드) */}
+          <Animated.View
+            style={{
+              ...StyleSheet.absoluteFillObject,
+              backgroundColor: 'rgba(0,0,0,0.4)',
+              opacity: sheetAnim,
+            }}
+          />
+          <TouchableOpacity className="flex-1" activeOpacity={1} onPress={closeMenu} />
+          {/* 시트 (슬라이드) */}
+          <Animated.View
+            style={{
+              transform: [
+                {
+                  translateY: sheetAnim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [SHEET_HEIGHT, 0],
+                  }),
+                },
+              ],
+            }}>
+            <View className="rounded-t-2xl bg-white pb-8 pt-2">
+              {/* 핸들 바 */}
+              <View className="mb-2 items-center py-2">
+                <View
+                  style={{
+                    width: 36,
+                    height: 4,
+                    borderRadius: 2,
+                    backgroundColor: COLORS.border,
+                  }}
+                />
+              </View>
+              <TouchableOpacity
+                className="flex-row items-center px-5 py-4"
+                disabled={isCompleting}
+                onPress={handleCompleteDeal}>
+                <MaterialCommunityIcons
+                  name="check-circle-outline"
+                  size={22}
+                  color={COLORS.primary}
+                />
+                <Text className="ml-4 text-base font-medium" style={{ color: COLORS.text }}>
+                  거래 완료
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                className="flex-row items-center px-5 py-4"
+                disabled={isLeaving}
+                onPress={handleLeaveChat}>
+                <MaterialCommunityIcons
+                  name="exit-to-app"
+                  size={22}
+                  color={dealCompleted ? COLORS.error : COLORS.textMuted}
+                />
+                <Text
+                  className="ml-4 text-base font-medium"
+                  style={{ color: dealCompleted ? COLORS.error : COLORS.textMuted }}>
+                  채팅방 나가기
+                </Text>
+                {!dealCompleted && (
+                  <Text className="ml-auto text-xs" style={{ color: COLORS.textMuted }}>
+                    거래 완료 후 가능
+                  </Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          </Animated.View>
+        </View>
+      </Modal>
 
       {/* 상품 정보 바 */}
       {chatInfo && (
@@ -148,6 +350,18 @@ export default function ChatDetail() {
           </View>
           <MaterialCommunityIcons name="chevron-right" size={20} color={COLORS.textMuted} />
         </TouchableOpacity>
+      )}
+
+      {/* 거래 완료 배너 */}
+      {dealCompleted && (
+        <View
+          className="flex-row items-center justify-center px-4 py-3"
+          style={{ backgroundColor: COLORS.primaryLight }}>
+          <MaterialCommunityIcons name="check-circle" size={18} color={COLORS.primary} />
+          <Text className="ml-2 text-sm font-semibold" style={{ color: COLORS.primary }}>
+            거래가 완료되었습니다
+          </Text>
+        </View>
       )}
 
       <KeyboardAvoidingView
@@ -185,6 +399,9 @@ export default function ChatDetail() {
                 formatMessageTime(nextMsg.created_at) !== formatMessageTime(msg.created_at) ||
                 getDateKey(nextMsg.created_at) !== getDateKey(msg.created_at);
 
+              const hasMedia = isMediaMessage(msg.content);
+              const isVideo = hasMedia && isVideoUrl(msg.content);
+
               return (
                 <View key={msg.message_id}>
                   {/* 날짜 구분선 */}
@@ -210,19 +427,53 @@ export default function ChatDetail() {
 
                     <View className={`max-w-[70%] ${isMe ? 'items-end' : 'items-start'}`}>
                       {/* 말풍선 */}
-                      <View
-                        className="rounded-2xl px-4 py-2.5"
-                        style={{
-                          backgroundColor: isMe ? COLORS.primary : COLORS.backgroundSecondary,
-                          borderBottomRightRadius: isMe ? 4 : 16,
-                          borderBottomLeftRadius: isMe ? 16 : 4,
-                        }}>
-                        <Text
-                          className="text-[15px] leading-6"
-                          style={{ color: isMe ? '#FFFFFF' : COLORS.text }}>
-                          {msg.content}
-                        </Text>
-                      </View>
+                      {hasMedia ? (
+                        <View
+                          className="overflow-hidden rounded-2xl"
+                          style={{
+                            borderBottomRightRadius: isMe ? 4 : 16,
+                            borderBottomLeftRadius: isMe ? 16 : 4,
+                          }}>
+                          {isVideo ? (
+                            <View
+                              className="items-center justify-center"
+                              style={{
+                                width: 200,
+                                height: 150,
+                                backgroundColor: COLORS.backgroundSecondary,
+                              }}>
+                              <MaterialCommunityIcons
+                                name="play-circle-outline"
+                                size={48}
+                                color={COLORS.textMuted}
+                              />
+                              <Text className="mt-1 text-xs" style={{ color: COLORS.textMuted }}>
+                                동영상
+                              </Text>
+                            </View>
+                          ) : (
+                            <Image
+                              source={{ uri: msg.content }}
+                              style={{ width: 200, height: 200 }}
+                              resizeMode="cover"
+                            />
+                          )}
+                        </View>
+                      ) : (
+                        <View
+                          className="rounded-2xl px-4 py-2.5"
+                          style={{
+                            backgroundColor: isMe ? COLORS.primary : COLORS.backgroundSecondary,
+                            borderBottomRightRadius: isMe ? 4 : 16,
+                            borderBottomLeftRadius: isMe ? 16 : 4,
+                          }}>
+                          <Text
+                            className="text-[15px] leading-6"
+                            style={{ color: isMe ? '#FFFFFF' : COLORS.text }}>
+                            {msg.content}
+                          </Text>
+                        </View>
+                      )}
                       {/* 읽음 표시 + 시간 */}
                       {showTime && (
                         <View
@@ -252,6 +503,17 @@ export default function ChatDetail() {
         <View
           className="flex-row items-center px-3 pb-2 pt-2"
           style={{ borderTopWidth: 1, borderTopColor: COLORS.border }}>
+          {/* 미디어 첨부 버튼 */}
+          <TouchableOpacity
+            className="mr-2 p-1"
+            onPress={handlePickMedia}
+            disabled={isSendingMedia}>
+            <MaterialCommunityIcons
+              name="plus-circle-outline"
+              size={ICON_SIZES.lg}
+              color={isSendingMedia ? COLORS.textMuted : COLORS.primary}
+            />
+          </TouchableOpacity>
           <View
             className="flex-1 flex-row items-center rounded-full px-4 py-2"
             style={{ backgroundColor: COLORS.backgroundSecondary }}>

--- a/app/mypage/index.tsx
+++ b/app/mypage/index.tsx
@@ -17,7 +17,13 @@ function countByStatus(products: ProductSummary[]) {
   let completed = 0;
   for (const p of products) {
     if (p.status === 'ON_SALE') bidding++;
-    else if (p.status === 'ENDED' || p.status === 'FAILED' || p.status === 'CANCELED') completed++;
+    else if (
+      p.status === 'ENDED' ||
+      p.status === 'FAILED' ||
+      p.status === 'CANCELED' ||
+      p.status === 'TRADED'
+    )
+      completed++;
     else inProgress++;
   }
   return { total: products.length, bidding, inProgress, completed };

--- a/app/product/[id].tsx
+++ b/app/product/[id].tsx
@@ -22,6 +22,7 @@ import { formatPrice } from '@/utils/format';
 import useAuthStore from '@/store/useAuthStore';
 import { useToggleWishMutation } from '@/hooks/wish/useToggleWishMutation';
 import { useCloseProductMutation } from '@/hooks/product/useCloseProductMutation';
+import { useProductSSE } from '@/hooks/product/useProductSSE';
 
 function formatRemainingTime(endTimeStr: string): string {
   const end = new Date(endTimeStr);
@@ -76,6 +77,12 @@ export default function ProductDetail() {
   const { mutate: toggleWish } = useToggleWishMutation();
   const { mutate: placeBid, isPending: isBidding } = usePlaceBidMutation();
   const { mutate: closeProduct, isPending: isClosing } = useCloseProductMutation();
+
+  // SSE 실시간 입찰 업데이트 (경매 진행 중일 때만)
+  useProductSSE({
+    productId,
+    enabled: product?.status === 'ON_SALE',
+  });
 
   if (isLoading) {
     return (

--- a/hooks/chat/useCompleteDealMutation.ts
+++ b/hooks/chat/useCompleteDealMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { completeDealApi } from '@/api/chat';
+import { ChatCompleteDealResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
+
+export function useCompleteDealMutation() {
+  const accessToken = useAccessToken();
+  const queryClient = useQueryClient();
+
+  return useMutation<ChatCompleteDealResponse, Error, number>({
+    mutationFn: async (chatId: number) => {
+      if (!accessToken) {
+        throw new Error('로그인이 필요합니다.');
+      }
+      return completeDealApi(chatId, accessToken);
+    },
+
+    onSuccess: (_data, chatId) => {
+      queryClient.invalidateQueries({ queryKey: ['chatMessages', chatId] });
+      queryClient.invalidateQueries({ queryKey: ['chatList'] });
+    },
+  });
+}

--- a/hooks/chat/useDealStatus.ts
+++ b/hooks/chat/useDealStatus.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { ChatListItem, ChatListResponse } from '@/api/types';
+import { useChatListQuery } from '@/hooks/chat/useChatListQuery';
+
+/**
+ * 거래 완료 상태를 서버 응답 기반으로 관리하는 훅
+ *
+ * - my_confirmed: 내가 거래 완료를 눌렀는지 (서버 상태)
+ * - partner_confirmed: 상대방이 거래 완료를 눌렀는지 (서버 상태)
+ * - dealCompleted: 내가 확인 완료
+ */
+export function useDealStatus(chatId: number) {
+  const queryClient = useQueryClient();
+  const { data: chatList } = useChatListQuery();
+  const chatInfo = chatList?.find((c) => c.chat_id === chatId);
+
+  const myConfirmed = chatInfo?.my_confirmed ?? false;
+  const partnerConfirmed = chatInfo?.partner_confirmed ?? false;
+  const dealCompleted = myConfirmed;
+
+  // 거래 완료 API 성공 후 캐시 낙관적 업데이트
+  const markMyConfirmed = useCallback(() => {
+    queryClient.setQueryData<ChatListResponse>(['chatList'], (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        data: old.data.map((item) =>
+          item.chat_id === chatId ? { ...item, my_confirmed: true } : item
+        ),
+      };
+    });
+  }, [queryClient, chatId]);
+
+  return { dealCompleted, myConfirmed, partnerConfirmed, markMyConfirmed };
+}

--- a/hooks/chat/useLeaveChatMutation.ts
+++ b/hooks/chat/useLeaveChatMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { leaveChatApi } from '@/api/chat';
+import { ChatLeaveResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
+
+export function useLeaveChatMutation() {
+  const accessToken = useAccessToken();
+  const queryClient = useQueryClient();
+
+  return useMutation<ChatLeaveResponse, Error, number>({
+    mutationFn: async (chatId: number) => {
+      if (!accessToken) {
+        throw new Error('로그인이 필요합니다.');
+      }
+      return leaveChatApi(chatId, accessToken);
+    },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chatList'] });
+    },
+  });
+}

--- a/hooks/chat/useSendChatMediaMutation.ts
+++ b/hooks/chat/useSendChatMediaMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ImagePickerAsset } from 'expo-image-picker';
+
+import { sendChatMediaApi } from '@/api/chat';
+import { ChatMediaSendResponse } from '@/api/types';
+import { useAccessToken } from '@/store/useAuthStore';
+
+type SendChatMediaParams = {
+  chatId: number;
+  file: ImagePickerAsset;
+};
+
+export function useSendChatMediaMutation() {
+  const accessToken = useAccessToken();
+  const queryClient = useQueryClient();
+
+  return useMutation<ChatMediaSendResponse, Error, SendChatMediaParams>({
+    mutationFn: async ({ chatId, file }) => {
+      if (!accessToken) {
+        throw new Error('로그인이 필요합니다.');
+      }
+      return sendChatMediaApi(chatId, file, accessToken);
+    },
+
+    onSuccess: (_data, { chatId }) => {
+      queryClient.invalidateQueries({ queryKey: ['chatMessages', chatId] });
+      queryClient.invalidateQueries({ queryKey: ['chatList'] });
+    },
+  });
+}

--- a/hooks/product/useProductSSE.ts
+++ b/hooks/product/useProductSSE.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import EventSource from 'react-native-sse';
 
 import { BidBroadcast, ProductDetailResponse } from '@/api/types';
 
@@ -25,7 +26,8 @@ export function useProductSSE({ productId, enabled = true }: UseProductSSEOption
     const eventSource = new EventSource(url);
     eventSourceRef.current = eventSource;
 
-    eventSource.onmessage = (event) => {
+    eventSource.addEventListener('message', (event) => {
+      if (!event.data) return;
       try {
         const broadcast: BidBroadcast = JSON.parse(event.data);
 
@@ -47,11 +49,11 @@ export function useProductSSE({ productId, enabled = true }: UseProductSSEOption
       } catch (e) {
         console.warn('[SSE] 메시지 파싱 실패:', e);
       }
-    };
+    });
 
-    eventSource.onerror = () => {
-      // 연결 끊김 시 EventSource가 자동 재연결 시도
-    };
+    eventSource.addEventListener('error', () => {
+      // 연결 끊김 시 react-native-sse가 자동 재연결 시도
+    });
 
     return () => {
       eventSource.close();

--- a/hooks/product/useProductSSE.ts
+++ b/hooks/product/useProductSSE.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { BidBroadcast, ProductDetailResponse } from '@/api/types';
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.trim().replace(/\/+$/, '') ?? '';
+
+type UseProductSSEOptions = {
+  productId: number;
+  enabled?: boolean;
+};
+
+export function useProductSSE({ productId, enabled = true }: UseProductSSEOptions) {
+  const queryClient = useQueryClient();
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled || productId <= 0 || !BASE_URL) return;
+
+    const url = `${BASE_URL}/api/products/${productId}/subscribe`;
+    const eventSource = new EventSource(url);
+    eventSourceRef.current = eventSource;
+
+    eventSource.onmessage = (event) => {
+      try {
+        const broadcast: BidBroadcast = JSON.parse(event.data);
+
+        // 상품 상세 캐시 업데이트 (현재가, 입찰 수)
+        queryClient.setQueryData<ProductDetailResponse>(['product', productId], (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            data: {
+              ...old.data,
+              current_price: broadcast.currentPrice,
+              bid_count: old.data.bid_count + 1,
+            },
+          };
+        });
+
+        // 입찰 내역 갱신
+        queryClient.invalidateQueries({ queryKey: ['bidHistory', productId] });
+      } catch (e) {
+        console.warn('[SSE] 메시지 파싱 실패:', e);
+      }
+    };
+
+    eventSource.onerror = () => {
+      // 연결 끊김 시 EventSource가 자동 재연결 시도
+    };
+
+    return () => {
+      eventSource.close();
+      eventSourceRef.current = null;
+    };
+  }, [productId, enabled, queryClient]);
+}

--- a/hooks/product/useProductsQuery.ts
+++ b/hooks/product/useProductsQuery.ts
@@ -15,5 +15,7 @@ export function useProductsQuery(params: ProductListParams = {}) {
     },
     select: (response) => response.data,
     enabled: isLoggedIn,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
   });
 }

--- a/hooks/storage/usePresignedUpload.ts
+++ b/hooks/storage/usePresignedUpload.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { getPresignedUrlApi, uploadToPresignedUrl } from '@/api/storage';
+import { useAccessToken } from '@/store/useAuthStore';
+
+type PresignedUploadParams = {
+  fileName: string;
+  contentType: string;
+  fileUri: string;
+};
+
+type PresignedUploadResult = {
+  objectUrl: string;
+};
+
+export function usePresignedUpload() {
+  const accessToken = useAccessToken();
+
+  return useMutation<PresignedUploadResult, Error, PresignedUploadParams>({
+    mutationFn: async ({ fileName, contentType, fileUri }) => {
+      if (!accessToken) {
+        throw new Error('로그인이 필요합니다.');
+      }
+
+      const { data } = await getPresignedUrlApi({ fileName, contentType }, accessToken);
+      await uploadToPresignedUrl(data.presignedUrl, fileUri, contentType);
+
+      return { objectUrl: data.objectUrl };
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-sse": "^1.2.1",
         "react-native-svg": "^15.12.1",
         "react-native-web": "^0.21.2",
         "react-native-worklets-core": "~1.3.3",
@@ -12061,6 +12062,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-sse": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-sse/-/react-native-sse-1.2.1.tgz",
+      "integrity": "sha512-zejanlScF+IB9tYnbdry0MT34qjBXbiV/E72qGz33W/tX1bx8MXsbB4lxiuPETc9v/008vYZ60yjIstW22VlVg==",
+      "license": "MIT"
     },
     "node_modules/react-native-svg": {
       "version": "15.12.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-sse": "^1.2.1",
     "react-native-svg": "^15.12.1",
     "react-native-web": "^0.21.2",
     "react-native-worklets-core": "~1.3.3",


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 이번 PR에서는 채팅 액션 기능 및 실시간 경매 업데이트 구현 진행하였습니다.

## 📝 변경 사항 요약 (Summary)

#58 [채팅 — 채팅방 나가기 / 거래 완료 / 미디어 전송]
  - 채팅 상세 헤더에 더보기(⋮) 버튼 추가 → 당근 스타일 하단 바텀시트 메뉴
    - 딤 배경 페이드 + 시트 슬라이드 애니메이션 분리 (Animated API)
  - 거래 완료: POST /api/chats/{chatId}/complete API 연동
    - 양쪽 확인 필요 안내 Alert 표시
    - 완료 시 상품 정보 바 아래 거래 완료 배너 렌더링
  - 채팅방 나가기: DELETE /api/chats/{chatId} API 연동
    - 거래 완료 전 나가기 차단 + 안내 메시지
    - 바텀시트에서 미완료 시 비활성화 스타일 + "거래 완료 후 가능" 텍스트
  - 이미지/비디오 전송: POST /api/chats/{chatId}/media (multipart/form-data)
    - 입력 영역 좌측 (+) 미디어 첨부 버튼 추가
    - expo-image-picker로 이미지/비디오 선택 후 전송
    - 미디어 메시지 렌더링 (이미지 썸네일 / 동영상 플레이스홀더)

#43 [상품 — SSE 실시간 경매 업데이트]
  - useProductSSE 훅: EventSource로 GET /api/products/{productId}/subscribe 구독
    - 새 입찰 시 BidBroadcast 수신 → current_price, bid_count 캐시 즉시 반영
    - bidHistory 쿼리 자동 갱신
    - 상품 상태 ON_SALE일 때만 활성화

#55 [스토리지 — Presigned URL S3 직접 업로드]
  - api/storage.ts: getPresignedUrlApi + uploadToPresignedUrl 함수 추가
  - usePresignedUpload 훅: URL 발급 → S3 PUT 업로드 → objectUrl 반환

  마이페이지 — 거래 내역 실시간 반영]
  - countByStatus에 TRADED 상태 추가 (거래 완료 상품이 종료 카운트에 집계)
  - useProductsQuery에 refetchOnWindowFocus + staleTime: 0 추가
  - _layout.tsx에 focusManager + AppState 리스너 등록 (RN 포그라운드 복귀 시 자동 refetch)

## 🔗 관련 이슈 (Related Issues)

- Closes #43, #58
- Related #55

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)